### PR TITLE
[cert] Add option to manually set signature in X509CertificateGenerator.create.

### DIFF
--- a/src/x509_cert_generator.ts
+++ b/src/x509_cert_generator.ts
@@ -40,7 +40,7 @@ export interface X509CertificateCreateParamsBase {
   /**
    * Signature for manually initialized certificates
    */
-  signature?: Buffer;
+  signature?: BufferSource;
 }
 
 /**

--- a/src/x509_cert_generator.ts
+++ b/src/x509_cert_generator.ts
@@ -37,6 +37,10 @@ export interface X509CertificateCreateParamsBase {
    * Signing algorithm
    */
   signingAlgorithm: Algorithm | EcdsaParams;
+  /**
+   * Signature for manually initialized certificates
+   */
+  signature?: Buffer;
 }
 
 /**
@@ -137,7 +141,7 @@ export class X509CertificateGenerator {
 
     // Sign
     const tbs = AsnConvert.serialize(asnX509.tbsCertificate);
-    const signature = await crypto.subtle.sign(signingAlgorithm, params.signingKey, tbs);
+    const signature = params.signature || await crypto.subtle.sign(signingAlgorithm, params.signingKey, tbs);
 
     // Convert WebCrypto signature to ASN.1 format
     const signatureFormatters = container.resolveAll<IAsnSignatureFormatter>(diAsnSignatureFormatter).reverse();

--- a/test/test_x509_cert_generator.ts
+++ b/test/test_x509_cert_generator.ts
@@ -19,8 +19,8 @@ const theTestX509CertificateGeneratorVector = [
         name: "CN=Test, O=Дом",
         subject: "CN=Test, O=Дом",
         issuer: "CN=Test, O=Дом",
-        notBefore: new Date("2020/01/01"),
-        notAfter: new Date("2040/01/02"),
+        notBefore: new Date(Date.UTC(2020, 0, 1, 8, 0, 0)), // UTCTime 2020-01-01 08:00:00 UTC
+        notAfter: new Date(Date.UTC(2040, 0, 2, 8, 0, 0)),  // UTCTime 2040-01-02 08:00:00 UTC
         signingAlgorithm: alg,
         extensions: [
           new x509.BasicConstraintsExtension(true, 2, true),
@@ -34,7 +34,9 @@ const theTestX509CertificateGeneratorVector = [
         ]
       },
 
-      testDate: new Date("2020/01/02"),
+      testDate: new Date(Date.UTC(2040, 0, 1, 8, 0, 1)),   // UTCTime 2040-01-01 08:00:01 UTC
+      testAfter: new Date(Date.UTC(2040, 0, 2, 8, 0, 1)),  // UTCTime 2040-01-02 08:00:01 UTC
+      testBefore: new Date(Date.UTC(2020, 0, 1, 0, 0, 1)), // UTCTime 2020-01-01 00:00:01 UTC
 
       certPem:
 `-----BEGIN CERTIFICATE-----
@@ -100,7 +102,13 @@ function testCertPreSigned(testEntry:any) {
     assert.equal(cert.toString("pem"), testEntry.certPem);
 
     const ok = await cert.verify({ date: testEntry.testDate });
-    assert.strictEqual(ok, true);
+    assert.strictEqual(ok, true, "certificate is not valid");
+
+    const validAfter = await cert.verify({ date: testEntry.testAfter });
+    assert.strictEqual(validAfter, false, "certificate is valid after");
+
+    const validBefore = await cert.verify({ date: testEntry.testBefore });
+    assert.strictEqual(validBefore, false, "certificate is valid before");
 
   });
 }

--- a/test/test_x509_cert_generator.ts
+++ b/test/test_x509_cert_generator.ts
@@ -2,8 +2,6 @@ import * as path from "path";
 import * as assert from "assert";
 import * as x509 from "../src";
 import { Crypto } from "@peculiar/webcrypto";
-import * as asn1Schema from "@peculiar/asn1-schema";
-import * as asn1X509 from "@peculiar/asn1-x509";
 
 const crypto = new Crypto();
 x509.cryptoProvider.set(crypto);
@@ -12,7 +10,7 @@ const alg = {
   name: "ECDSA",
   hash: "SHA-256",
   namedCurve: "P-256",
-}
+};
 
 const theTestX509CertificateGeneratorVector = [
   {
@@ -36,6 +34,8 @@ const theTestX509CertificateGeneratorVector = [
         ]
       },
 
+      testDate: new Date("2020/01/02"),
+
       certPem:
 `-----BEGIN CERTIFICATE-----
 MIIBmjCCAT+gAwIBAgIBATAKBggqhkjOPQQDAjAgMQ0wCwYDVQQDEwRUZXN0MQ8w
@@ -48,13 +48,13 @@ BjAkBgNVHSAEHTAbMAYGBCoDBAUwBwYFKgMEBQYwCAYGKgMEBQYHMAoGCCqGSM49
 BAMCA0kAMEYCIQDskjb7BN3ppaQKIZdJJ5617PoFFfluQ3NuGPj6ljK7vAIhAKRc
 4iVJsJUDSiCw1upeannIYgmJcKWmLBKjGmOyLa+O
 -----END CERTIFICATE-----`,
-      certDer: '3082019a3082013fa003020102020101300a06082a8648ce3d0403023020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc301e170d3230303130313038303030305a170d3430303130323038303030305a3020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701a36a306830120603551d130101ff040830060101ff020102301c0603551d250101ff0412301006062a03040506070606530405060708300e0603551d0f0101ff04040302010630240603551d20041d301b300606042a030405300706052a03040506300806062a0304050607300a06082a8648ce3d0403020349003046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
-      privateKey: '308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b02010104201823f412a803f2cfbae8574e00fb8993b17683057e099e6b9fd0e2d7da40c97ca1440342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701',
-      publicKey: '3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701',
-      signatureDer: '3046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
-      signature: 'ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbca45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
+      certDer: "3082019a3082013fa003020102020101300a06082a8648ce3d0403023020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc301e170d3230303130313038303030305a170d3430303130323038303030305a3020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701a36a306830120603551d130101ff040830060101ff020102301c0603551d250101ff0412301006062a03040506070606530405060708300e0603551d0f0101ff04040302010630240603551d20041d301b300606042a030405300706052a03040506300806062a0304050607300a06082a8648ce3d0403020349003046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e",
+      privateKey: "308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b02010104201823f412a803f2cfbae8574e00fb8993b17683057e099e6b9fd0e2d7da40c97ca1440342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701",
+      publicKey: "3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701",
+      signatureDer: "3046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e",
+      signature: "ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbca45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e",
     },
-]
+];
 
 function testCertSelfSign(testEntry:any) {
 
@@ -68,25 +68,25 @@ function testCertSelfSign(testEntry:any) {
 
       ...testEntry.certContents,
     });
-    const ok = await cert.verify({ date: new Date("2020/01/01 12:00") });
+    const ok = await cert.verify({ date: testEntry.testDate });
     assert.strictEqual(ok, true);
-  })
+  });
 }
 
 function testCertPreSigned(testEntry:any) {
 
   it("Test X509CertificateGenerator.create pre-signed", async () => {
 
-    const signature = Buffer.from(testEntry.signature, 'hex')
-    const extractable = true
-    const publicKeyRaw =  Buffer.from(testEntry.publicKey,'hex')
+    const signature = Buffer.from(testEntry.signature, "hex");
+    const extractable = true;
+    const publicKeyRaw =  Buffer.from(testEntry.publicKey,"hex");
     const publicKey = await crypto.subtle.importKey(
       "spki",
       publicKeyRaw,
       alg,
       extractable,
       ["verify"]
-    )
+    );
     assert.ok(publicKey);
 
     const cert = await x509.X509CertificateGenerator.create({
@@ -96,19 +96,19 @@ function testCertPreSigned(testEntry:any) {
       ...testEntry.certContents,
     });
 
-    assert.equal(cert.toString('hex'), testEntry.certDer);
-    assert.equal(cert.toString('pem'), testEntry.certPem);
+    assert.equal(cert.toString("hex"), testEntry.certDer);
+    assert.equal(cert.toString("pem"), testEntry.certPem);
 
-    const ok = await cert.verify({ date: new Date("2020/01/01 12:00") });
+    const ok = await cert.verify({ date: testEntry.testDate });
     assert.strictEqual(ok, true);
 
-  })
+  });
 }
 
 
 describe(path.basename(__filename), () => {
   theTestX509CertificateGeneratorVector.forEach(testEntry => {
-      testCertSelfSign(testEntry)
-      testCertPreSigned(testEntry)
-  })
-})
+      testCertSelfSign(testEntry);
+      testCertPreSigned(testEntry);
+  });
+});

--- a/test/test_x509_cert_generator.ts
+++ b/test/test_x509_cert_generator.ts
@@ -1,0 +1,114 @@
+import * as path from "path";
+import * as assert from "assert";
+import * as x509 from "../src";
+import { Crypto } from "@peculiar/webcrypto";
+import * as asn1Schema from "@peculiar/asn1-schema";
+import * as asn1X509 from "@peculiar/asn1-x509";
+
+const crypto = new Crypto();
+x509.cryptoProvider.set(crypto);
+
+const alg = {
+  name: "ECDSA",
+  hash: "SHA-256",
+  namedCurve: "P-256",
+}
+
+const theTestX509CertificateGeneratorVector = [
+  {
+      certContents: {
+        serialNumber: "01",
+        name: "CN=Test, O=Дом",
+        subject: "CN=Test, O=Дом",
+        issuer: "CN=Test, O=Дом",
+        notBefore: new Date("2020/01/01"),
+        notAfter: new Date("2040/01/02"),
+        signingAlgorithm: alg,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension(["1.2.3.4.5.6.7", "2.3.4.5.6.7.8"], true),
+          new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
+          new x509.CertificatePolicyExtension([
+            "1.2.3.4.5",
+            "1.2.3.4.5.6",
+            "1.2.3.4.5.6.7",
+          ]),
+        ]
+      },
+
+      certPem:
+`-----BEGIN CERTIFICATE-----
+MIIBmjCCAT+gAwIBAgIBATAKBggqhkjOPQQDAjAgMQ0wCwYDVQQDEwRUZXN0MQ8w
+DQYDVQQKDAbQlNC+0LwwHhcNMjAwMTAxMDgwMDAwWhcNNDAwMTAyMDgwMDAwWjAg
+MQ0wCwYDVQQDEwRUZXN0MQ8wDQYDVQQKDAbQlNC+0LwwWTATBgcqhkjOPQIBBggq
+hkjOPQMBBwNCAAQYR3iB8GEm6pKJ9OJZRg7BJz6gePT+GGxwZZgLJEPEo3G1U318
+Y/37xzjsmd+xR+Kuz46UBvXkua7LQq3pTacBo2owaDASBgNVHRMBAf8ECDAGAQH/
+AgECMBwGA1UdJQEB/wQSMBAGBioDBAUGBwYGUwQFBgcIMA4GA1UdDwEB/wQEAwIB
+BjAkBgNVHSAEHTAbMAYGBCoDBAUwBwYFKgMEBQYwCAYGKgMEBQYHMAoGCCqGSM49
+BAMCA0kAMEYCIQDskjb7BN3ppaQKIZdJJ5617PoFFfluQ3NuGPj6ljK7vAIhAKRc
+4iVJsJUDSiCw1upeannIYgmJcKWmLBKjGmOyLa+O
+-----END CERTIFICATE-----`,
+      certDer: '3082019a3082013fa003020102020101300a06082a8648ce3d0403023020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc301e170d3230303130313038303030305a170d3430303130323038303030305a3020310d300b0603550403130454657374310f300d060355040a0c06d094d0bed0bc3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701a36a306830120603551d130101ff040830060101ff020102301c0603551d250101ff0412301006062a03040506070606530405060708300e0603551d0f0101ff04040302010630240603551d20041d301b300606042a030405300706052a03040506300806062a0304050607300a06082a8648ce3d0403020349003046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
+      privateKey: '308187020100301306072a8648ce3d020106082a8648ce3d030107046d306b02010104201823f412a803f2cfbae8574e00fb8993b17683057e099e6b9fd0e2d7da40c97ca1440342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701',
+      publicKey: '3059301306072a8648ce3d020106082a8648ce3d0301070342000418477881f06126ea9289f4e259460ec1273ea078f4fe186c7065980b2443c4a371b5537d7c63fdfbc738ec99dfb147e2aecf8e9406f5e4b9aecb42ade94da701',
+      signatureDer: '3046022100ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbc022100a45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
+      signature: 'ec9236fb04dde9a5a40a219749279eb5ecfa0515f96e43736e18f8fa9632bbbca45ce22549b095034a20b0d6ea5e6a79c862098970a5a62c12a31a63b22daf8e',
+    },
+]
+
+function testCertSelfSign(testEntry:any) {
+
+  it("Test X509CertificateGenerator.create self-signed", async () => {
+
+    const keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+    assert.ok(keys.publicKey);
+    assert.ok(keys.privateKey);
+    const cert = await x509.X509CertificateGenerator.createSelfSigned({
+      keys: keys,
+
+      ...testEntry.certContents,
+    });
+    const ok = await cert.verify({ date: new Date("2020/01/01 12:00") });
+    assert.strictEqual(ok, true);
+  })
+}
+
+function testCertPreSigned(testEntry:any) {
+
+  it("Test X509CertificateGenerator.create pre-signed", async () => {
+
+    const signature = Buffer.from(testEntry.signature, 'hex')
+    const extractable = true
+    const publicKeyRaw =  Buffer.from(testEntry.publicKey,'hex')
+    const publicKey = await crypto.subtle.importKey(
+      "spki",
+      publicKeyRaw,
+      alg,
+      extractable,
+      ["verify"]
+    )
+    assert.ok(publicKey);
+
+    const cert = await x509.X509CertificateGenerator.create({
+      publicKey: publicKey,
+      signature: signature,
+
+      ...testEntry.certContents,
+    });
+
+    assert.equal(cert.toString('hex'), testEntry.certDer);
+    assert.equal(cert.toString('pem'), testEntry.certPem);
+
+    const ok = await cert.verify({ date: new Date("2020/01/01 12:00") });
+    assert.strictEqual(ok, true);
+
+  })
+}
+
+
+describe(path.basename(__filename), () => {
+  theTestX509CertificateGeneratorVector.forEach(testEntry => {
+      testCertSelfSign(testEntry)
+      testCertPreSigned(testEntry)
+  })
+})


### PR DESCRIPTION
When creating an x509 certificate manually, field-by-field, for verification purposes, with only the public key, there needs to be an option to set the signature:

```
        var publicKey = await SubtleCrypto.importKey(
            "raw",
            publicKeyRaw,
            Certificate.Algorithm,
            true, // Extractable?
            ["verify"] 
        )
        var publicKeySpki = await SubtleCrypto.exportKey('spki', publicKey)

       const cert = await x509.X509CertificateGenerator.create ({
            version: 2,
            serialNumber: serialNumber.toString('hex'),
            subject: subject.toString(),
            issuer: issuer.toString(),
            notBefore: new Date(notBefore),
            notAfter: new Date(notAfter),
            signingAlgorithm: Certificate.Algorithm,
            publicKey: publicKeySpki,
            signingKey: publicKey,
            signature: signature,
        })
```