### PR TITLE
Fix exporting SPKI with RSA-PSS algorithm

### DIFF
--- a/test/crypto.ts
+++ b/test/crypto.ts
@@ -290,6 +290,16 @@ D314IEOg4mnS8Q==
 
     const spki = Convert.FromHex("30820122300d06092a864886f70d01010105000382010f003082010a0282010100a4737ac5ec77f06df3486264a3a17c783143e9023073af169cc245023b4711526b4a721832943bbb59be53d241f3203c1a5eac9e1d5bb57bc0644d943dd63525090a70e1484db4b5ac03185ee897ae8ebabf255ebfc77cfebec928ac0b1fceb33b60238ac2ba3f016c035a53a3011828c2e9bafdd7e2a797d94dcbd79ec54a5ae3c92abef565b2ea6bb4af89e2f7e4dd1b52978bb828cb44843ace8c9ad7f80bef7ffedc8b73a04b6ec44cd65fc6ba8fc216c6ca4bbc99677695439391a4d17893b8f54d6755b681210660f7865748fc1126e21e4d9cdcee436c3ce5ebd91912d08713cb91613ecde2e8af694daa27110b8d588f34e82e88aa56315d15428db90203010001");
 
+    context("export", () => {
+      it("with RSA-PSS algorithm", async () => {
+        // RSA-PSS algorithm is not supported for SPKI in browsers
+        // x509 module reconverts it to RSA-PKCS1
+        const b64 = "MIIBUzA+BgkqhkiG9w0BAQowMaANMAsGCWCGSAFlAwQCAaEaMBgGCSqGSIb3DQEBCDALBglghkgBZQMEAgGiBAICAN4DggEPADCCAQoCggEBANbStMMWVHrgQgc1DZ4nr2XegPv069OhV0uiMwgM7QzvPot1TmCH4biJ/YMrBN9IY+hwGT30wSUkp0/EruMducqUQ/jy3zf/7KHqZnHOi7LDPdan3JvoJQrdY0BeMcdVFfvLP7S9Jfpd7ZM90h7oof+JcaMhoJWPNEH92a1viwFcw9t+wruK15/mftnmdgbWpFmDvK14YDz6hVWQ4lQyvS0HYHO4KCX+H7vb2gl0u1gDslrS1At5ky9OLs3l6QZ5AHP9Qxzh7HWnBaqupuD/n12umE4nlNE5GZegFWjhcwHgZ4pl7Q7QQnMRK86D6T5I88/10iFR66nMGZ+Y/lwyGM8CAwEAAQ==";
+        const key = new x509.PublicKey(b64);
+        const cryptoKey = await key.export();
+        assert.strictEqual(cryptoKey.type, "public");
+      });
+    });
     context("getThumbprint", () => {
 
       it("default", async () => {


### PR DESCRIPTION
This pull request fixes an issue where the PublicKey class was not correctly exporting SPKI with RSA-PSS algorithm in browsers. The code now converts RSA-PSS algorithm to RSA-PKCS1 before exporting.