### PR TITLE
feat: issuer alternative name extension

### DIFF
--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -4,6 +4,7 @@ export * from "./extended_key_usage";
 export * from "./key_usages";
 export * from "./subject_key_identifier";
 export * from "./subject_alt_name";
+export * from "./issuer_alt_name";
 export * from "./certificate_policy";
 export * from "./crl_distribution_points";
 export * from "./authority_info_access";

--- a/src/extensions/issuer_alt_name.ts
+++ b/src/extensions/issuer_alt_name.ts
@@ -1,0 +1,61 @@
+import { AsnConvert } from "@peculiar/asn1-schema";
+import * as asn1X509 from "@peculiar/asn1-x509";
+import { BufferSourceConverter } from "pvtsutils";
+import { Extension } from "../extension";
+import { GeneralNames, type JsonGeneralNames } from "../general_name";
+import type { TextObject } from "../text_converter";
+
+/**
+ * Represents the Issuer Alternative Name certificate extension
+ */
+export class IssuerAlternativeNameExtension extends Extension {
+	public names!: GeneralNames;
+
+	public static override NAME = "Issuer Alternative Name";
+
+	/**
+	 * Creates a new instance from DER encoded buffer
+	 * @param raw DER encoded buffer
+	 */
+	public constructor(raw: BufferSource);
+	/**
+	 * Creates a new instance
+	 * @param data JSON representation of IAN
+	 * @param critical Indicates where extension is critical. Default is `false`
+	 */
+	public constructor(data?: JsonGeneralNames, critical?: boolean);
+	public constructor(...args: any[]) {
+		if (BufferSourceConverter.isBufferSource(args[0])) {
+			super(args[0]);
+		} else {
+			super(
+				asn1X509.id_ce_issuerAltName,
+				args[1],
+				new GeneralNames(args[0] || []).rawData,
+			);
+		}
+	}
+
+	onInit(asn: asn1X509.Extension) {
+		super.onInit(asn);
+
+		// value
+		const value = AsnConvert.parse(
+			asn.extnValue,
+			asn1X509.IssueAlternativeName,
+		);
+
+		this.names = new GeneralNames(value);
+	}
+
+	public override toTextObject(): TextObject {
+		const obj = this.toTextObjectWithoutValue();
+
+		const namesObj = this.names.toTextObject();
+		for (const key in namesObj) {
+			obj[key] = namesObj[key];
+		}
+
+		return obj;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ extensions.ExtensionFactory.register(asnX509.id_ce_keyUsage, extensions.KeyUsage
 extensions.ExtensionFactory.register(asnX509.id_ce_subjectKeyIdentifier, extensions.SubjectKeyIdentifierExtension);
 extensions.ExtensionFactory.register(asnX509.id_ce_authorityKeyIdentifier, extensions.AuthorityKeyIdentifierExtension);
 extensions.ExtensionFactory.register(asnX509.id_ce_subjectAltName, extensions.SubjectAlternativeNameExtension);
+extensions.ExtensionFactory.register(asnX509.id_ce_issuerAltName, extensions.IssuerAlternativeNameExtension);
 extensions.ExtensionFactory.register(asnX509.id_ce_cRLDistributionPoints, extensions.CRLDistributionPointsExtension);
 extensions.ExtensionFactory.register(asnX509.id_pe_authorityInfoAccess, extensions.AuthorityInfoAccessExtension);
 

--- a/test/text.ts
+++ b/test/text.ts
@@ -136,6 +136,18 @@ describe("text", () => {
           ].join("\n"),
         },
         {
+          name: "Issuer Alternative Name",
+          factory: async () => {
+            return new x509.IssuerAlternativeNameExtension([
+              { type: "dns", value: "some.com" },
+            ]);
+          },
+          want: [
+            "Issuer Alternative Name:",
+            "  DNS: some.com",
+          ].join("\n"),
+        },
+        {
           name: "Unknown Extension",
           factory: async () => {
             return new x509.Extension("1.2.3.4.5", false, new Uint8Array([2, 3, 1, 0, 1]));


### PR DESCRIPTION
Adds an `IssuerAlternativeName` extension, which is essentially the same as the `SubjectAlternativeName` one.

Closes #94.