### PR TITLE
fix: pass crypto

### DIFF
--- a/src/x509_cert_generator.ts
+++ b/src/x509_cert_generator.ts
@@ -130,7 +130,7 @@ export class X509CertificateGenerator {
       spki = await crypto.subtle.exportKey("spki", params.publicKey);
     }
 
-    const serialNumber = generateCertificateSerialNumber(params.serialNumber);
+    const serialNumber = generateCertificateSerialNumber(params.serialNumber, crypto);
     const notBefore = params.notBefore || new Date();
     const notAfter = params.notAfter || new Date(notBefore.getTime() + 31536000000); // 1 year
 


### PR DESCRIPTION
We noticed an error after upgrading to 1.14. We always provide the crypto instance, and don't register any with the crypto provider since it's different based on the context.