### PR TITLE
test: drop access to private X509Crl.tbs getter

### DIFF
--- a/test/x509_crl.ts
+++ b/test/x509_crl.ts
@@ -56,7 +56,6 @@ describe("X509Crl", () => {
     expect(crl.nextUpdate?.getTime()).toBe(nextUpdate.getTime());
     expect(crl.signatureAlgorithm.name).toBe("ECDSA");
     expect(crl.signature).toBeDefined();
-    expect(crl.tbs).toBeDefined();
   });
 
   it("should have correct entries", () => {


### PR DESCRIPTION
The assertion at test/x509_crl.ts:59 reaches into a `private`
getter (X509Crl.tbs, mirrored on X509Certificate.tbs) which
emits TS2341 under `tsc --noEmit`. The lint + coverage CI step
uses vitest's transpile-only path so it slipped through #127.

The remaining assertions in `should parse properties correctly`
already cover the tbsCertList structure (issuer, thisUpdate,
nextUpdate, signatureAlgorithm, signature), so dropping the
private-property check loses no meaningful coverage.