### PR TITLE
feat(algorithm): register ML-DSA and SLH-DSA AlgorithmProvider handlers (FIPS 204 / FIPS 205)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@peculiar/asn1-rsa": "^2.6.0",
         "@peculiar/asn1-schema": "^2.6.0",
         "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-x509-post-quantum": "^2.7.0",
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1",
         "tsyringe": "^4.10.0"
@@ -2410,128 +2411,154 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@peculiar/asn1-cms": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
-      "integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+    "node_modules/@peculiar/asn1-asym-key": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-asym-key/-/asn1-asym-key-2.7.0.tgz",
+      "integrity": "sha512-mR447yj2ZMuMXZ1mngFQXiA0dB8gWwWzcE+pjNL3w+EKCV8qwsXJHBg0wV4nA73r4PXSBtW1AZVoJ5f0Oejbmg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
-      "integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
-      "integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
-      "integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-pkcs8": "^2.6.0",
-        "@peculiar/asn1-rsa": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
-      "integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
-      "integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-pfx": "^2.6.0",
-        "@peculiar/asn1-pkcs8": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "@peculiar/asn1-x509-attr": "^2.6.0",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
-      "integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
       "license": "MIT",
       "dependencies": {
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
-      "integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
-      "integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-post-quantum": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-post-quantum/-/asn1-x509-post-quantum-2.7.0.tgz",
+      "integrity": "sha512-/jQEJoMcivedxK4atLQpF1Z97FalrGZ3mXPFYzMyNxSHFyCl1KPLhjOReZMaq49Gm+xSQWs4ctcN1f9LnUabhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-asym-key": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
@@ -2563,6 +2590,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.2.tgz",
+      "integrity": "sha512-lHhrK/1QAXGn0GUYkme7t4zo0mQ5QIp+/8YED6pzu8AQFdjA9bAXeNURAHk4sw7n9i89MMNQVom0LkuuLUZMog==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/webcrypto": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@peculiar/asn1-rsa": "^2.6.0",
     "@peculiar/asn1-schema": "^2.6.0",
     "@peculiar/asn1-x509": "^2.6.0",
+    "@peculiar/asn1-x509-post-quantum": "^2.7.0",
     "pvtsutils": "^1.3.6",
     "tslib": "^2.8.1",
     "tsyringe": "^4.10.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export * from "./ec_algorithm";
 export * from "./sha_algorithm";
 export * from "./ec_signature_formatter";
 export * from "./ed_algorithm";
+export * from "./ml_dsa_algorithm";
+export * from "./slh_dsa_algorithm";
 export * from "./attribute";
 export * from "./extension";
 export * from "./name";

--- a/src/ml_dsa_algorithm.ts
+++ b/src/ml_dsa_algorithm.ts
@@ -1,0 +1,50 @@
+import { AlgorithmIdentifier } from "@peculiar/asn1-x509";
+import {
+  id_ml_dsa_44,
+  id_ml_dsa_65,
+  id_ml_dsa_87,
+} from "@peculiar/asn1-x509-post-quantum";
+import { container, injectable } from "tsyringe";
+import { diAlgorithm, IAlgorithm } from "./algorithm";
+
+/**
+ * Provider for the NIST FIPS 204 module-lattice digital signature algorithms
+ * (ML-DSA-44 / -65 / -87). Per FIPS 204 §5 and NIST CSOR the AlgorithmIdentifier
+ * carries no parameters (absent, not NULL), matching the Ed25519 convention.
+ */
+@injectable()
+export class MlDsaAlgorithm implements IAlgorithm {
+  public toAsnAlgorithm(alg: Algorithm): AlgorithmIdentifier | null {
+    let algorithm: string | null = null;
+    switch (alg.name.toLowerCase()) {
+      case "ml-dsa-44":
+        algorithm = id_ml_dsa_44;
+        break;
+      case "ml-dsa-65":
+        algorithm = id_ml_dsa_65;
+        break;
+      case "ml-dsa-87":
+        algorithm = id_ml_dsa_87;
+        break;
+    }
+    if (algorithm) {
+      return new AlgorithmIdentifier({ algorithm });
+    }
+    return null;
+  }
+
+  public toWebAlgorithm(alg: AlgorithmIdentifier): Algorithm | null {
+    switch (alg.algorithm) {
+      case id_ml_dsa_44:
+        return { name: "ML-DSA-44" };
+      case id_ml_dsa_65:
+        return { name: "ML-DSA-65" };
+      case id_ml_dsa_87:
+        return { name: "ML-DSA-87" };
+    }
+    return null;
+  }
+}
+
+// register ML-DSA algorithm provider as a singleton object
+container.registerSingleton(diAlgorithm, MlDsaAlgorithm);

--- a/src/slh_dsa_algorithm.ts
+++ b/src/slh_dsa_algorithm.ts
@@ -1,0 +1,105 @@
+import { AlgorithmIdentifier } from "@peculiar/asn1-x509";
+import {
+  id_slh_dsa_sha2_128s,
+  id_slh_dsa_sha2_128f,
+  id_slh_dsa_sha2_192s,
+  id_slh_dsa_sha2_192f,
+  id_slh_dsa_sha2_256s,
+  id_slh_dsa_sha2_256f,
+  id_slh_dsa_shake_128s,
+  id_slh_dsa_shake_128f,
+  id_slh_dsa_shake_192s,
+  id_slh_dsa_shake_192f,
+  id_slh_dsa_shake_256s,
+  id_slh_dsa_shake_256f,
+} from "@peculiar/asn1-x509-post-quantum";
+import { container, injectable } from "tsyringe";
+import { diAlgorithm, IAlgorithm } from "./algorithm";
+
+/**
+ * Provider for the NIST FIPS 205 stateless hash-based digital signature
+ * algorithms (SLH-DSA). All 12 parameter sets per FIPS 205 §9. Per FIPS 205
+ * and NIST CSOR the AlgorithmIdentifier carries no parameters (absent, not
+ * NULL), matching the Ed25519 convention.
+ */
+@injectable()
+export class SlhDsaAlgorithm implements IAlgorithm {
+  public toAsnAlgorithm(alg: Algorithm): AlgorithmIdentifier | null {
+    let algorithm: string | null = null;
+    switch (alg.name.toLowerCase()) {
+      case "slh-dsa-sha2-128s":
+        algorithm = id_slh_dsa_sha2_128s;
+        break;
+      case "slh-dsa-sha2-128f":
+        algorithm = id_slh_dsa_sha2_128f;
+        break;
+      case "slh-dsa-sha2-192s":
+        algorithm = id_slh_dsa_sha2_192s;
+        break;
+      case "slh-dsa-sha2-192f":
+        algorithm = id_slh_dsa_sha2_192f;
+        break;
+      case "slh-dsa-sha2-256s":
+        algorithm = id_slh_dsa_sha2_256s;
+        break;
+      case "slh-dsa-sha2-256f":
+        algorithm = id_slh_dsa_sha2_256f;
+        break;
+      case "slh-dsa-shake-128s":
+        algorithm = id_slh_dsa_shake_128s;
+        break;
+      case "slh-dsa-shake-128f":
+        algorithm = id_slh_dsa_shake_128f;
+        break;
+      case "slh-dsa-shake-192s":
+        algorithm = id_slh_dsa_shake_192s;
+        break;
+      case "slh-dsa-shake-192f":
+        algorithm = id_slh_dsa_shake_192f;
+        break;
+      case "slh-dsa-shake-256s":
+        algorithm = id_slh_dsa_shake_256s;
+        break;
+      case "slh-dsa-shake-256f":
+        algorithm = id_slh_dsa_shake_256f;
+        break;
+    }
+    if (algorithm) {
+      return new AlgorithmIdentifier({ algorithm });
+    }
+    return null;
+  }
+
+  public toWebAlgorithm(alg: AlgorithmIdentifier): Algorithm | null {
+    switch (alg.algorithm) {
+      case id_slh_dsa_sha2_128s:
+        return { name: "SLH-DSA-SHA2-128s" };
+      case id_slh_dsa_sha2_128f:
+        return { name: "SLH-DSA-SHA2-128f" };
+      case id_slh_dsa_sha2_192s:
+        return { name: "SLH-DSA-SHA2-192s" };
+      case id_slh_dsa_sha2_192f:
+        return { name: "SLH-DSA-SHA2-192f" };
+      case id_slh_dsa_sha2_256s:
+        return { name: "SLH-DSA-SHA2-256s" };
+      case id_slh_dsa_sha2_256f:
+        return { name: "SLH-DSA-SHA2-256f" };
+      case id_slh_dsa_shake_128s:
+        return { name: "SLH-DSA-SHAKE-128s" };
+      case id_slh_dsa_shake_128f:
+        return { name: "SLH-DSA-SHAKE-128f" };
+      case id_slh_dsa_shake_192s:
+        return { name: "SLH-DSA-SHAKE-192s" };
+      case id_slh_dsa_shake_192f:
+        return { name: "SLH-DSA-SHAKE-192f" };
+      case id_slh_dsa_shake_256s:
+        return { name: "SLH-DSA-SHAKE-256s" };
+      case id_slh_dsa_shake_256f:
+        return { name: "SLH-DSA-SHAKE-256f" };
+    }
+    return null;
+  }
+}
+
+// register SLH-DSA algorithm provider as a singleton object
+container.registerSingleton(diAlgorithm, SlhDsaAlgorithm);

--- a/test/ml_dsa_slh_dsa_algorithm.ts
+++ b/test/ml_dsa_slh_dsa_algorithm.ts
@@ -1,0 +1,93 @@
+import {
+  describe, it, expect, beforeAll,
+} from "vitest";
+import { container } from "tsyringe";
+import {
+  id_ml_dsa_44,
+  id_ml_dsa_65,
+  id_ml_dsa_87,
+  id_slh_dsa_sha2_128s,
+  id_slh_dsa_sha2_128f,
+  id_slh_dsa_sha2_192s,
+  id_slh_dsa_sha2_192f,
+  id_slh_dsa_sha2_256s,
+  id_slh_dsa_sha2_256f,
+  id_slh_dsa_shake_128s,
+  id_slh_dsa_shake_128f,
+  id_slh_dsa_shake_192s,
+  id_slh_dsa_shake_192f,
+  id_slh_dsa_shake_256s,
+  id_slh_dsa_shake_256f,
+} from "@peculiar/asn1-x509-post-quantum";
+import { AlgorithmIdentifier } from "@peculiar/asn1-x509";
+import { AlgorithmProvider, diAlgorithmProvider } from "../src";
+
+describe("ML-DSA + SLH-DSA AlgorithmProvider wiring (FIPS 204 / FIPS 205)", () => {
+  let algorithmProvider: AlgorithmProvider;
+
+  beforeAll(() => {
+    algorithmProvider = container.resolve<AlgorithmProvider>(diAlgorithmProvider);
+  });
+
+  // Each row: [WebCrypto name, NIST CSOR OID constant, OID string]
+  const mlDsaVectors: readonly [string, string][] = [
+    ["ML-DSA-44", id_ml_dsa_44],
+    ["ML-DSA-65", id_ml_dsa_65],
+    ["ML-DSA-87", id_ml_dsa_87],
+  ];
+
+  const slhDsaVectors: readonly [string, string][] = [
+    ["SLH-DSA-SHA2-128s", id_slh_dsa_sha2_128s],
+    ["SLH-DSA-SHA2-128f", id_slh_dsa_sha2_128f],
+    ["SLH-DSA-SHA2-192s", id_slh_dsa_sha2_192s],
+    ["SLH-DSA-SHA2-192f", id_slh_dsa_sha2_192f],
+    ["SLH-DSA-SHA2-256s", id_slh_dsa_sha2_256s],
+    ["SLH-DSA-SHA2-256f", id_slh_dsa_sha2_256f],
+    ["SLH-DSA-SHAKE-128s", id_slh_dsa_shake_128s],
+    ["SLH-DSA-SHAKE-128f", id_slh_dsa_shake_128f],
+    ["SLH-DSA-SHAKE-192s", id_slh_dsa_shake_192s],
+    ["SLH-DSA-SHAKE-192f", id_slh_dsa_shake_192f],
+    ["SLH-DSA-SHAKE-256s", id_slh_dsa_shake_256s],
+    ["SLH-DSA-SHAKE-256f", id_slh_dsa_shake_256f],
+  ];
+
+  describe("ML-DSA (FIPS 204)", () => {
+    for (const [name, oid] of mlDsaVectors) {
+      it(`${name} → ${oid} with absent parameters`, () => {
+        const asn = algorithmProvider.toAsnAlgorithm({ name } as Algorithm);
+        expect(asn.algorithm).toBe(oid);
+        expect(asn.parameters).toBe(undefined);
+      });
+
+      it(`${oid} → { name: "${name}" }`, () => {
+        const web = algorithmProvider.toWebAlgorithm(new AlgorithmIdentifier({ algorithm: oid }));
+        expect(web).toEqual({ name });
+      });
+
+      it(`${name} name lookup is case-insensitive`, () => {
+        const asn = algorithmProvider.toAsnAlgorithm({ name: name.toLowerCase() } as Algorithm);
+        expect(asn.algorithm).toBe(oid);
+      });
+    }
+  });
+
+  describe("SLH-DSA (FIPS 205)", () => {
+    for (const [name, oid] of slhDsaVectors) {
+      it(`${name} → ${oid} with absent parameters`, () => {
+        const asn = algorithmProvider.toAsnAlgorithm({ name } as Algorithm);
+        expect(asn.algorithm).toBe(oid);
+        expect(asn.parameters).toBe(undefined);
+      });
+
+      it(`${oid} → { name: "${name}" }`, () => {
+        const web = algorithmProvider.toWebAlgorithm(new AlgorithmIdentifier({ algorithm: oid }));
+        expect(web).toEqual({ name });
+      });
+
+      it(`${name} name lookup is case-insensitive`, () => {
+        const asn = algorithmProvider.toAsnAlgorithm({ name: name.toLowerCase() } as Algorithm);
+        expect(asn.algorithm).toBe(oid);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Implements the AlgorithmProvider side of #133 by registering
handlers for the FIPS 204 ML-DSA and FIPS 205 SLH-DSA digital
signature algorithms.

## What's added

- `MlDsaAlgorithm` — 3 variants (ML-DSA-44 / -65 / -87)
- `SlhDsaAlgorithm` — 12 variants (all FIPS 205 parameter sets:
  SHA2 / SHAKE × 128/192/256 × s/f)
- Both follow the Ed25519 convention: AlgorithmIdentifier carries
  no parameters (absent, not NULL) per NIST CSOR registration
- Singleton registration via `tsyringe` against `diAlgorithm`,
  matching the pattern used by `ed_algorithm.ts`
- 45 tests covering name→OID, OID→name, and case-insensitive
  name lookup for each variant

## Dependency note

Adds `@peculiar/asn1-x509-post-quantum@^2.7.0`, which carries the
OID constants from PeculiarVentures/asn1-schema#120.

That package transitively requires `@peculiar/asn1-schema@^2.7.0`,
so the package-lock.json refresh is structurally required: keeping
sibling `@peculiar/asn1-*` packages at 2.6.x produces runtime
schema-registration errors against the new asn1-schema (visible in
existing tests like `test/text.ts > attributes > Challenge
Password`).

Closes #133