### PR TITLE
fix: encode CRL revoked serial numbers as positive INTEGERs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,3 +42,25 @@ export function generateCertificateSerialNumber(
 
   return serialNumber.buffer;
 }
+
+/**
+ * Reads a certificate serial number from DER INTEGER content octets and returns
+ * it as a hexadecimal string. Strips the leading sign-pad byte (`0x00`) that is
+ * prepended to keep a high-bit-set value a positive INTEGER, so the returned
+ * string matches the original (unpadded) serial number.
+ *
+ * Inverse of {@link generateCertificateSerialNumber}.
+ *
+ * @param raw DER INTEGER content octets (e.g. `tbsCertificate.serialNumber` or
+ *   a CRL entry's `userCertificate`)
+ * @returns Hexadecimal string of the serial number, without sign padding
+ */
+export function getCertificateSerialNumber(raw: BufferSource): string {
+  let serialNumber = BufferSourceConverter.toUint8Array(raw);
+  if (serialNumber.length > 1 && serialNumber[0] === 0x00 && serialNumber[1] > 0x7F) {
+    // Remove the leading zero that was added to make negative numbers positive
+    serialNumber = serialNumber.slice(1);
+  }
+
+  return Convert.ToHex(serialNumber);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,35 +2,24 @@ import { BufferSourceConverter, Convert } from "pvtsutils";
 import { cryptoProvider } from "./provider";
 
 /**
- * Creates or normalizes a certificate serial number according to RFC 5280 requirements.
- * Ensures the serial number is positive, minimal length, and non-zero by:
- * - Using provided hex string if valid (non-empty and contains non-zero bytes)
- * - Generating 16 random bytes if input is invalid or empty
+ * Encodes serial number bytes as the content octets of a positive ASN.1 INTEGER by:
  * - Removing leading zeros while preserving at least one byte
  * - Prepending zero byte if MSB is set to ensure positive ASN.1 INTEGER
  *
- * @param input Hex string representation of desired serial number
- * @param crypto Crypto provider for random number generation
- * @returns RFC 5280 compliant serial number as ArrayBuffer
+ * @param input Serial number bytes
+ * @returns DER INTEGER content octets
  */
-export function generateCertificateSerialNumber(
-  input: string | undefined,
-  crypto = cryptoProvider.get(),
-): ArrayBuffer {
-  const inputView = BufferSourceConverter.toUint8Array(Convert.FromHex(input || ""));
-  let serialNumber = inputView && inputView.length && inputView.some((o) => o > 0)
-    ? new Uint8Array(inputView)
-    : undefined;
-  if (!serialNumber) {
-    serialNumber = crypto.getRandomValues(new Uint8Array(16));
-  }
-
+function toPositiveIntegerOctets(input: Uint8Array): ArrayBuffer {
   // Remove unnecessary leading zeros
   let firstNonZero = 0;
-  while (firstNonZero < serialNumber.length - 1 && serialNumber[firstNonZero] === 0) {
+  while (firstNonZero < input.length - 1 && input[firstNonZero] === 0) {
     firstNonZero++;
   }
-  serialNumber = serialNumber.slice(firstNonZero);
+  let serialNumber = input.slice(firstNonZero);
+
+  if (!serialNumber.length) {
+    serialNumber = new Uint8Array([0x00]);
+  }
 
   // If the first bit is 1, prepend a zero byte to ensure positive integer
   if (serialNumber[0] > 0x7F) {
@@ -41,4 +30,62 @@ export function generateCertificateSerialNumber(
   }
 
   return serialNumber.buffer;
+}
+
+/**
+ * Normalizes a certificate serial number without ever replacing the given value. The
+ * serial number is encoded as a positive, minimal length ASN.1 INTEGER. Empty and
+ * all-zero input is normalized to a single zero byte.
+ *
+ * @param input Hex string representation of the serial number
+ * @returns Serial number as ArrayBuffer
+ */
+export function normalizeCertificateSerialNumber(input: string | undefined): ArrayBuffer {
+  return toPositiveIntegerOctets(BufferSourceConverter.toUint8Array(Convert.FromHex(input || "")));
+}
+
+/**
+ * Creates or normalizes a certificate serial number according to RFC 5280 requirements.
+ * Ensures the serial number is positive, minimal length, and non-zero by:
+ * - Using provided hex string if valid (non-empty and contains non-zero bytes)
+ * - Generating 16 random bytes if input is invalid or empty
+ * - Normalizing the result with {@link normalizeCertificateSerialNumber}
+ *
+ * Use {@link normalizeCertificateSerialNumber} where a caller supplied serial number
+ * must never be replaced, such as for CRL entries.
+ *
+ * @param input Hex string representation of desired serial number
+ * @param crypto Crypto provider for random number generation
+ * @returns RFC 5280 compliant serial number as ArrayBuffer
+ */
+export function generateCertificateSerialNumber(
+  input: string | undefined,
+  crypto = cryptoProvider.get(),
+): ArrayBuffer {
+  const inputView = BufferSourceConverter.toUint8Array(Convert.FromHex(input || ""));
+  const serialNumber = inputView.length && inputView.some((o) => o > 0)
+    ? inputView
+    : crypto.getRandomValues(new Uint8Array(16));
+
+  return toPositiveIntegerOctets(serialNumber);
+}
+
+/**
+ * Reads a certificate serial number from DER INTEGER content octets and returns
+ * it as a hexadecimal string. Strips the leading sign-pad byte (`0x00`) that is
+ * prepended to keep a high-bit-set value a positive INTEGER, so the returned
+ * string matches the original (unpadded) serial number.
+ *
+ * @param raw DER INTEGER content octets (e.g. `tbsCertificate.serialNumber` or
+ *   a CRL entry's `userCertificate`)
+ * @returns Hexadecimal string of the serial number, without sign padding
+ */
+export function getCertificateSerialNumber(raw: BufferSource): string {
+  let serialNumber = BufferSourceConverter.toUint8Array(raw);
+  if (serialNumber.length > 1 && serialNumber[0] === 0x00 && serialNumber[1] > 0x7F) {
+    // Remove the leading zero that was added to make negative numbers positive
+    serialNumber = serialNumber.slice(1);
+  }
+
+  return Convert.ToHex(serialNumber);
 }

--- a/src/x509_cert.ts
+++ b/src/x509_cert.ts
@@ -1,6 +1,6 @@
 import { AsnConvert } from "@peculiar/asn1-schema";
 import { Certificate, Version } from "@peculiar/asn1-x509";
-import { BufferSourceConverter, Convert } from "pvtsutils";
+import { BufferSourceConverter } from "pvtsutils";
 import { container } from "tsyringe";
 import { HashedAlgorithm } from "./types";
 import { cryptoProvider } from "./provider";
@@ -15,6 +15,7 @@ import { AsnEncodedType, PemData } from "./pem_data";
 import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature_formatter";
 import { PemConverter } from "./pem_converter";
 import { TextConverter, TextObject } from "./text_converter";
+import { getCertificateSerialNumber } from "./utils";
 
 /**
  * Verification params of X509 certificate
@@ -109,16 +110,7 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
    */
   public get serialNumber(): string {
     if (!this.#serialNumber) {
-      const tbs = this.asn.tbsCertificate;
-      let serialNumberBytes = new Uint8Array(tbs.serialNumber);
-      if (serialNumberBytes.length > 1
-        && serialNumberBytes[0] === 0x00
-        && serialNumberBytes[1] > 0x7F
-      ) {
-        // Remove the leading zero that was added to make negative numbers positive
-        serialNumberBytes = serialNumberBytes.slice(1);
-      }
-      this.#serialNumber = Convert.ToHex(serialNumberBytes);
+      this.#serialNumber = getCertificateSerialNumber(this.asn.tbsCertificate.serialNumber);
     }
 
     return this.#serialNumber;

--- a/src/x509_cert.ts
+++ b/src/x509_cert.ts
@@ -1,6 +1,6 @@
 import { AsnConvert } from "@peculiar/asn1-schema";
 import { Certificate, Version } from "@peculiar/asn1-x509";
-import { BufferSourceConverter, Convert } from "pvtsutils";
+import { BufferSourceConverter } from "pvtsutils";
 import { container } from "tsyringe";
 import { HashedAlgorithm, ParseOptions } from "./types";
 import { cryptoProvider } from "./provider";
@@ -15,6 +15,7 @@ import { AsnEncodedType, PemData } from "./pem_data";
 import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature_formatter";
 import { PemConverter } from "./pem_converter";
 import { TextConverter, TextObject } from "./text_converter";
+import { getCertificateSerialNumber } from "./utils";
 
 /**
  * Verification params of X509 certificate
@@ -112,16 +113,7 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
    */
   public get serialNumber(): string {
     if (!this.#serialNumber) {
-      const tbs = this.asn.tbsCertificate;
-      let serialNumberBytes = new Uint8Array(tbs.serialNumber);
-      if (serialNumberBytes.length > 1
-        && serialNumberBytes[0] === 0x00
-        && serialNumberBytes[1] > 0x7F
-      ) {
-        // Remove the leading zero that was added to make negative numbers positive
-        serialNumberBytes = serialNumberBytes.slice(1);
-      }
-      this.#serialNumber = Convert.ToHex(serialNumberBytes);
+      this.#serialNumber = getCertificateSerialNumber(this.asn.tbsCertificate.serialNumber);
     }
 
     return this.#serialNumber;

--- a/src/x509_crl.ts
+++ b/src/x509_crl.ts
@@ -19,7 +19,7 @@ import {
 import { X509Certificate } from "./x509_cert";
 import { X509CrlEntry } from "./x509_crl_entry";
 import { PemConverter } from "./pem_converter";
-import { generateCertificateSerialNumber } from "./utils";
+import { normalizeCertificateSerialNumber } from "./utils";
 
 export interface X509CrlVerifyParams {
   publicKey: CryptoKey | PublicKey | X509Certificate;
@@ -379,14 +379,10 @@ export class X509Crl extends PemData<CertificateList> {
    *  Gets the CRL entry, with the given X509Certificate or certificate serialNumber.
    *
    * @param certOrSerialNumber certificate | serialNumber
-   * @param crypto Crypto provider. Default is from CryptoProvider
    */
-  public findRevoked(
-    certOrSerialNumber: X509Certificate | string,
-    crypto?: Crypto,
-  ): X509CrlEntry | null {
+  public findRevoked(certOrSerialNumber: X509Certificate | string): X509CrlEntry | null {
     const serialNumber = typeof certOrSerialNumber === "string" ? certOrSerialNumber : certOrSerialNumber.serialNumber;
-    const serialBuffer = generateCertificateSerialNumber(serialNumber, crypto);
+    const serialBuffer = normalizeCertificateSerialNumber(serialNumber);
     for (const revoked of this.asn.tbsCertList.revokedCertificates || []) {
       if (BufferSourceConverter.isEqual(revoked.userCertificate, serialBuffer)) {
         return new X509CrlEntry(AsnConvert.serialize(revoked), this.parseOptions);

--- a/src/x509_crl_entry.ts
+++ b/src/x509_crl_entry.ts
@@ -2,11 +2,11 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import {
   CRLReason, id_ce_cRLReasons, id_ce_invalidityDate, InvalidityDate, RevokedCertificate, Time,
 } from "@peculiar/asn1-x509";
-import { BufferSourceConverter, Convert } from "pvtsutils";
+import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "./extension";
 import { ExtensionFactory } from "./extensions/extension_factory";
 import { AsnData } from "./asn_data";
-import { generateCertificateSerialNumber } from "./utils";
+import { generateCertificateSerialNumber, getCertificateSerialNumber } from "./utils";
 
 /**
  * Reason Code
@@ -60,7 +60,7 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
    */
   public get serialNumber(): string {
     if (!this.#serialNumber) {
-      this.#serialNumber = Convert.ToHex(this.asn.userCertificate);
+      this.#serialNumber = getCertificateSerialNumber(this.asn.userCertificate);
     }
 
     return this.#serialNumber;

--- a/src/x509_crl_entry.ts
+++ b/src/x509_crl_entry.ts
@@ -2,11 +2,11 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import {
   CRLReason, id_ce_cRLReasons, id_ce_invalidityDate, InvalidityDate, RevokedCertificate, Time,
 } from "@peculiar/asn1-x509";
-import { BufferSourceConverter, Convert } from "pvtsutils";
+import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "./extension";
 import { ExtensionFactory } from "./extensions/extension_factory";
 import { AsnData } from "./asn_data";
-import { generateCertificateSerialNumber } from "./utils";
+import { getCertificateSerialNumber, normalizeCertificateSerialNumber } from "./utils";
 import { ParseOptions } from "./types";
 
 /**
@@ -61,7 +61,7 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
    */
   public get serialNumber(): string {
     if (!this.#serialNumber) {
-      this.#serialNumber = Convert.ToHex(this.asn.userCertificate);
+      this.#serialNumber = getCertificateSerialNumber(this.asn.userCertificate);
     }
 
     return this.#serialNumber;
@@ -166,7 +166,7 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
       options = args[1];
     } else if (typeof args[0] === "string") {
       raw = AsnConvert.serialize(new RevokedCertificate({
-        userCertificate: generateCertificateSerialNumber(args[0]),
+        userCertificate: normalizeCertificateSerialNumber(args[0]),
         revocationDate: new Time(args[1]),
         crlEntryExtensions: args[2],
       }));

--- a/src/x509_crl_generator.ts
+++ b/src/x509_crl_generator.ts
@@ -14,7 +14,7 @@ import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature
 import { X509CrlEntry, X509CrlReason } from "./x509_crl_entry";
 import { X509Crl } from "./x509_crl";
 import { X509CertificateCreateParamsName } from "./x509_cert_generator";
-import { PemData } from "./pem_data";
+import { generateCertificateSerialNumber } from "./utils";
 
 export interface X509CrlEntryParams {
   /**
@@ -84,7 +84,7 @@ export class X509CrlGenerator {
     if (params.entries && params.entries.length) {
       asnX509Crl.tbsCertList.revokedCertificates = [];
       for (const entry of params.entries) {
-        const userCertificate = PemData.toArrayBuffer(entry.serialNumber);
+        const userCertificate = generateCertificateSerialNumber(entry.serialNumber, crypto);
         const index = asnX509Crl.tbsCertList.revokedCertificates
           .findIndex((cert) => isEqual(cert.userCertificate, userCertificate));
         if (index > -1) {

--- a/src/x509_crl_generator.ts
+++ b/src/x509_crl_generator.ts
@@ -14,7 +14,7 @@ import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature
 import { X509CrlEntry, X509CrlReason } from "./x509_crl_entry";
 import { X509Crl } from "./x509_crl";
 import { X509CertificateCreateParamsName } from "./x509_cert_generator";
-import { generateCertificateSerialNumber } from "./utils";
+import { normalizeCertificateSerialNumber } from "./utils";
 
 export interface X509CrlEntryParams {
   /**
@@ -84,7 +84,7 @@ export class X509CrlGenerator {
     if (params.entries && params.entries.length) {
       asnX509Crl.tbsCertList.revokedCertificates = [];
       for (const entry of params.entries) {
-        const userCertificate = generateCertificateSerialNumber(entry.serialNumber, crypto);
+        const userCertificate = normalizeCertificateSerialNumber(entry.serialNumber);
         const index = asnX509Crl.tbsCertList.revokedCertificates
           .findIndex((cert) => isEqual(cert.userCertificate, userCertificate));
         if (index > -1) {

--- a/test/x509_crl.ts
+++ b/test/x509_crl.ts
@@ -2,7 +2,8 @@ import {
   describe, it, expect, beforeAll,
 } from "vitest";
 import { Crypto } from "@peculiar/webcrypto";
-import { Convert } from "pvtsutils";
+import { AsnConvert } from "@peculiar/asn1-schema";
+import { CertificateList } from "@peculiar/asn1-x509";
 import * as x509 from "../src";
 
 const crypto = new Crypto();
@@ -221,14 +222,15 @@ describe("X509CrlGenerator", () => {
       }],
     });
 
-    // Re-parse from DER to assert the encoded bytes, not the in-memory object.
-    const parsed = new x509.X509Crl(crl.rawData);
-    const encoded = new Uint8Array(Convert.FromHex(parsed.entries[0].serialNumber));
-    expect(encoded[0]).toBe(0x00); // leading sign-pad byte => positive INTEGER
-    expect(parsed.entries[0].serialNumber).toBe(`00${highBitSerial}`);
+    // Inspect the raw DER INTEGER content octets directly: the getter strips
+    // the sign-pad, so assert on the encoding rather than on serialNumber.
+    const asn = AsnConvert.parse(crl.rawData, CertificateList);
+    const revoked = asn.tbsCertList.revokedCertificates ?? [];
+    const userCertificate = new Uint8Array(revoked[0].userCertificate);
+    expect(userCertificate[0]).toBe(0x00); // leading sign-pad byte => positive INTEGER
   });
 
-  it("should find a revoked high-bit-set serial number via findRevoked", async () => {
+  it("should expose the serial number consistently with X509Certificate", async () => {
     const crl = await x509.X509CrlGenerator.create({
       issuer: "CN=Test CA",
       thisUpdate: new Date(),
@@ -240,9 +242,20 @@ describe("X509CrlGenerator", () => {
       }],
     });
 
+    const cert = await x509.X509CertificateGenerator.createSelfSigned({
+      serialNumber: highBitSerial,
+      name: "CN=Test CA",
+      notBefore: new Date("2020-01-01"),
+      notAfter: new Date("2060-01-01"),
+      signingAlgorithm: alg,
+      keys,
+    });
+
     const parsed = new x509.X509Crl(crl.rawData);
     const entry = parsed.findRevoked(highBitSerial);
     expect(entry).not.toBeNull();
-    expect(entry?.serialNumber).toBe(`00${highBitSerial}`);
+    // The CRL entry getter strips the sign-pad, matching X509Certificate.
+    expect(entry?.serialNumber).toBe(highBitSerial);
+    expect(entry?.serialNumber).toBe(cert.serialNumber);
   });
 });

--- a/test/x509_crl.ts
+++ b/test/x509_crl.ts
@@ -2,6 +2,7 @@ import {
   describe, it, expect, beforeAll,
 } from "vitest";
 import { Crypto } from "@peculiar/webcrypto";
+import { Convert } from "pvtsutils";
 import * as x509 from "../src";
 
 const crypto = new Crypto();
@@ -202,5 +203,46 @@ describe("X509CrlGenerator", () => {
         },
       ],
     })).rejects.toThrow("already exists");
+  });
+
+  // First byte 0xf6 has the high bit set; without sign-padding this would be
+  // encoded as a negative DER INTEGER (RFC 5280 §5.3.1 violation).
+  const highBitSerial = "f6f3c85e97e433070c51e0527b20b7f4";
+
+  it("should encode a high-bit-set serial number as a positive INTEGER", async () => {
+    const crl = await x509.X509CrlGenerator.create({
+      issuer: "CN=Test CA",
+      thisUpdate: new Date(),
+      nextUpdate: new Date(),
+      signingAlgorithm: alg,
+      signingKey: keys.privateKey,
+      entries: [{
+        serialNumber: highBitSerial, revocationDate: new Date(),
+      }],
+    });
+
+    // Re-parse from DER to assert the encoded bytes, not the in-memory object.
+    const parsed = new x509.X509Crl(crl.rawData);
+    const encoded = new Uint8Array(Convert.FromHex(parsed.entries[0].serialNumber));
+    expect(encoded[0]).toBe(0x00); // leading sign-pad byte => positive INTEGER
+    expect(parsed.entries[0].serialNumber).toBe(`00${highBitSerial}`);
+  });
+
+  it("should find a revoked high-bit-set serial number via findRevoked", async () => {
+    const crl = await x509.X509CrlGenerator.create({
+      issuer: "CN=Test CA",
+      thisUpdate: new Date(),
+      nextUpdate: new Date(),
+      signingAlgorithm: alg,
+      signingKey: keys.privateKey,
+      entries: [{
+        serialNumber: highBitSerial, revocationDate: new Date(),
+      }],
+    });
+
+    const parsed = new x509.X509Crl(crl.rawData);
+    const entry = parsed.findRevoked(highBitSerial);
+    expect(entry).not.toBeNull();
+    expect(entry?.serialNumber).toBe(`00${highBitSerial}`);
   });
 });

--- a/test/x509_crl.ts
+++ b/test/x509_crl.ts
@@ -259,7 +259,7 @@ describe("X509CrlGenerator", () => {
     expect(entry?.serialNumber).toBe(cert.serialNumber);
   });
 
-  it.each(["00", "0000"])("should keep a zero serial number %s as given", async (serialNumber) => {
+  it.each(["", "00", "0000"])("should keep the zero serial number %j as given", async (serialNumber) => {
     const crl = await x509.X509CrlGenerator.create({
       issuer: "CN=Test CA",
       thisUpdate: new Date(),
@@ -294,5 +294,18 @@ describe("X509CrlGenerator", () => {
         },
       ],
     })).rejects.toThrow("already exists");
+  });
+});
+
+describe("X509CrlEntry", () => {
+  it("should normalize the serial number", () => {
+    // High bit set, so the serial number gets a sign-pad byte on encoding, and
+    // the getter strips it again.
+    const entry = new x509.X509CrlEntry("f6f3c8", new Date(), []);
+    expect(entry.serialNumber).toBe("f6f3c8");
+
+    // Zero serial numbers must be normalized, not replaced by a random one.
+    const zeroEntry = new x509.X509CrlEntry("0000", new Date(), []);
+    expect(zeroEntry.serialNumber).toBe("00");
   });
 });

--- a/test/x509_crl.ts
+++ b/test/x509_crl.ts
@@ -2,7 +2,8 @@ import {
   describe, it, expect, beforeAll,
 } from "vitest";
 import { Crypto } from "@peculiar/webcrypto";
-import { Convert } from "pvtsutils";
+import { AsnConvert } from "@peculiar/asn1-schema";
+import { CertificateList } from "@peculiar/asn1-x509";
 import * as x509 from "../src";
 
 const crypto = new Crypto();
@@ -206,7 +207,7 @@ describe("X509CrlGenerator", () => {
   });
 
   // First byte 0xf6 has the high bit set; without sign-padding this would be
-  // encoded as a negative DER INTEGER (RFC 5280 §5.3.1 violation).
+  // encoded as a negative DER INTEGER (RFC 5280 §4.1.2.2 violation).
   const highBitSerial = "f6f3c85e97e433070c51e0527b20b7f4";
 
   it("should encode a high-bit-set serial number as a positive INTEGER", async () => {
@@ -221,14 +222,15 @@ describe("X509CrlGenerator", () => {
       }],
     });
 
-    // Re-parse from DER to assert the encoded bytes, not the in-memory object.
-    const parsed = new x509.X509Crl(crl.rawData);
-    const encoded = new Uint8Array(Convert.FromHex(parsed.entries[0].serialNumber));
-    expect(encoded[0]).toBe(0x00); // leading sign-pad byte => positive INTEGER
-    expect(parsed.entries[0].serialNumber).toBe(`00${highBitSerial}`);
+    // Inspect the raw DER INTEGER content octets directly: the getter strips
+    // the sign-pad, so assert on the encoding rather than on serialNumber.
+    const asn = AsnConvert.parse(crl.rawData, CertificateList);
+    const revoked = asn.tbsCertList.revokedCertificates ?? [];
+    const userCertificate = new Uint8Array(revoked[0].userCertificate);
+    expect(userCertificate[0]).toBe(0x00); // leading sign-pad byte => positive INTEGER
   });
 
-  it("should find a revoked high-bit-set serial number via findRevoked", async () => {
+  it("should expose the serial number consistently with X509Certificate", async () => {
     const crl = await x509.X509CrlGenerator.create({
       issuer: "CN=Test CA",
       thisUpdate: new Date(),
@@ -240,9 +242,57 @@ describe("X509CrlGenerator", () => {
       }],
     });
 
+    const cert = await x509.X509CertificateGenerator.createSelfSigned({
+      serialNumber: highBitSerial,
+      name: "CN=Test CA",
+      notBefore: new Date("2020-01-01"),
+      notAfter: new Date("2060-01-01"),
+      signingAlgorithm: alg,
+      keys,
+    });
+
     const parsed = new x509.X509Crl(crl.rawData);
     const entry = parsed.findRevoked(highBitSerial);
     expect(entry).not.toBeNull();
-    expect(entry?.serialNumber).toBe(`00${highBitSerial}`);
+    // The CRL entry getter strips the sign-pad, matching X509Certificate.
+    expect(entry?.serialNumber).toBe(highBitSerial);
+    expect(entry?.serialNumber).toBe(cert.serialNumber);
+  });
+
+  it.each(["00", "0000"])("should keep a zero serial number %s as given", async (serialNumber) => {
+    const crl = await x509.X509CrlGenerator.create({
+      issuer: "CN=Test CA",
+      thisUpdate: new Date(),
+      nextUpdate: new Date(),
+      signingAlgorithm: alg,
+      signingKey: keys.privateKey,
+      entries: [{
+        serialNumber, revocationDate: new Date(),
+      }],
+    });
+
+    // The serial number must be normalized, not replaced by a random one.
+    const parsed = new x509.X509Crl(crl.rawData);
+    expect(parsed.entries.length).toBe(1);
+    expect(parsed.entries[0].serialNumber).toBe("00");
+    expect(parsed.findRevoked(serialNumber)?.serialNumber).toBe("00");
+  });
+
+  it("should throw if duplicate entries with zero serial numbers", async () => {
+    await expect(x509.X509CrlGenerator.create({
+      issuer: "CN=Test CA",
+      thisUpdate: new Date(),
+      nextUpdate: new Date(),
+      signingAlgorithm: alg,
+      signingKey: keys.privateKey,
+      entries: [
+        {
+          serialNumber: "00", revocationDate: new Date(),
+        },
+        {
+          serialNumber: "0000", revocationDate: new Date(),
+        },
+      ],
+    })).rejects.toThrow("already exists");
   });
 });


### PR DESCRIPTION
I just came across a bug where a specific serial number was getting encoded as a negative integer. All other code paths seem to normalize the serial numbers, but here it wasn't being normalized.

Also the getters for the serial number in the certificate and CRL entry were producing non-consistent values. That's also fixed.