### PR TITLE
feat: expose asn1 parse options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.0",
-        "@peculiar/asn1-csr": "^2.6.0",
-        "@peculiar/asn1-ecc": "^2.6.0",
-        "@peculiar/asn1-pkcs9": "^2.6.0",
-        "@peculiar/asn1-rsa": "^2.6.0",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.0",
-        "@peculiar/asn1-x509-post-quantum": "^2.7.0",
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-csr": "^2.8.0",
+        "@peculiar/asn1-ecc": "^2.8.0",
+        "@peculiar/asn1-pkcs9": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-post-quantum": "^2.8.0",
         "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1",
         "tsyringe": "^4.10.0"
@@ -2412,154 +2412,154 @@
       }
     },
     "node_modules/@peculiar/asn1-asym-key": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-asym-key/-/asn1-asym-key-2.7.0.tgz",
-      "integrity": "sha512-mR447yj2ZMuMXZ1mngFQXiA0dB8gWwWzcE+pjNL3w+EKCV8qwsXJHBg0wV4nA73r4PXSBtW1AZVoJ5f0Oejbmg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-asym-key/-/asn1-asym-key-2.8.0.tgz",
+      "integrity": "sha512-FcGHUtVtC4VMUyWzPOI+Xq8hug/X3w0fMDeATWeSTSoPahEGveCu63qw2PqcDYxWmF6Jk+Tz6qyn1h0PD6x6HQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-pkcs8": "^2.7.0",
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
-      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "@peculiar/asn1-x509-attr": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
-      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
-      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
-      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.7.0",
-        "@peculiar/asn1-pkcs8": "^2.7.0",
-        "@peculiar/asn1-rsa": "^2.7.0",
-        "@peculiar/asn1-schema": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
-      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
-      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.7.0",
-        "@peculiar/asn1-pfx": "^2.7.0",
-        "@peculiar/asn1-pkcs8": "^2.7.0",
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "@peculiar/asn1-x509-attr": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
-      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
-      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
-      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.8.0",
         "@peculiar/utils": "^2.0.2",
-        "asn1js": "^3.0.6",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
-      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-post-quantum": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-post-quantum/-/asn1-x509-post-quantum-2.7.0.tgz",
-      "integrity": "sha512-/jQEJoMcivedxK4atLQpF1Z97FalrGZ3mXPFYzMyNxSHFyCl1KPLhjOReZMaq49Gm+xSQWs4ctcN1f9LnUabhA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-post-quantum/-/asn1-x509-post-quantum-2.8.0.tgz",
+      "integrity": "sha512-+QOXWSHsbLk3ABurnNnphtiaqk9EtL35Qo1U1WchCpPXSEbUdq791ZtJjMhlhnVPgd4RaFfCqILBosE9llS+dw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-asym-key": "^2.7.0",
-        "@peculiar/asn1-schema": "^2.7.0",
-        "@peculiar/asn1-x509": "^2.7.0",
-        "asn1js": "^3.0.6",
+        "@peculiar/asn1-asym-key": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
       }
     },
@@ -3729,13 +3729,13 @@
       }
     },
     "node_modules/asn1js": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
-      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -6689,12 +6689,12 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
       "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -70,14 +70,14 @@
     "vitest": "^4.0.9"
   },
   "dependencies": {
-    "@peculiar/asn1-cms": "^2.6.0",
-    "@peculiar/asn1-csr": "^2.6.0",
-    "@peculiar/asn1-ecc": "^2.6.0",
-    "@peculiar/asn1-pkcs9": "^2.6.0",
-    "@peculiar/asn1-rsa": "^2.6.0",
-    "@peculiar/asn1-schema": "^2.6.0",
-    "@peculiar/asn1-x509": "^2.6.0",
-    "@peculiar/asn1-x509-post-quantum": "^2.7.0",
+    "@peculiar/asn1-cms": "^2.8.0",
+    "@peculiar/asn1-csr": "^2.8.0",
+    "@peculiar/asn1-ecc": "^2.8.0",
+    "@peculiar/asn1-pkcs9": "^2.8.0",
+    "@peculiar/asn1-rsa": "^2.8.0",
+    "@peculiar/asn1-schema": "^2.8.0",
+    "@peculiar/asn1-x509": "^2.8.0",
+    "@peculiar/asn1-x509-post-quantum": "^2.8.0",
     "pvtsutils": "^1.3.6",
     "tslib": "^2.8.1",
     "tsyringe": "^4.10.0"

--- a/src/asn_data.ts
+++ b/src/asn_data.ts
@@ -5,6 +5,7 @@ import {
 import {
   TextConverter, TextObject, TextObjectConvertible,
 } from "./text_converter";
+import { ParseOptions } from "./types";
 
 export type AsnDataStringFormat = "asn" | "text" | "hex" | "base64" | "base64url";
 
@@ -15,6 +16,18 @@ export abstract class AsnData<T> implements TextObjectConvertible {
   public static NAME = "ASN";
 
   #rawData!: ArrayBuffer;
+
+  /**
+   * ASN.1 parse options
+   */
+  #options?: ParseOptions;
+
+  /**
+   * Gets the ASN.1 parse options the instance was created with
+   */
+  protected get parseOptions(): ParseOptions | undefined {
+    return this.#options;
+  }
 
   /**
    * Gets a DER encoded buffer
@@ -37,7 +50,7 @@ export abstract class AsnData<T> implements TextObjectConvertible {
    * @param raw DER encoded buffer
    * @param type ASN.1 convertible class for `@peculiar/asn1-schema` schema
    */
-  public constructor(raw: BufferSource, type: new() => T);
+  public constructor(raw: BufferSource, type: new() => T, options?: ParseOptions);
   /**
    * ASN.1 object
    * @param asn
@@ -45,8 +58,9 @@ export abstract class AsnData<T> implements TextObjectConvertible {
   public constructor(asn: T);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      // raw, type
-      this.asn = AsnConvert.parse<T>(args[0], args[1]);
+      // raw, type, options?
+      this.#options = args[2];
+      this.asn = AsnConvert.parse<T>(args[0], args[1], args[2]);
       this.#rawData = BufferSourceConverter.toArrayBuffer(args[0]);
       this.onInit(this.asn);
     } else {
@@ -77,7 +91,7 @@ export abstract class AsnData<T> implements TextObjectConvertible {
   public toString(format: AsnDataStringFormat = "text"): string {
     switch (format) {
       case "asn":
-        return AsnConvert.toString(this.rawData);
+        return AsnConvert.toString(this.rawData, this.#options);
       case "text":
         return TextConverter.serialize(this.toTextObject());
       case "hex":

--- a/src/asn_data.ts
+++ b/src/asn_data.ts
@@ -54,8 +54,9 @@ export abstract class AsnData<T> implements TextObjectConvertible {
   /**
    * ASN.1 object
    * @param asn
+   * @param options ASN.1 parse options used for nested ASN.1 payloads
    */
-  public constructor(asn: T);
+  public constructor(asn: T, options?: ParseOptions);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
       // raw, type, options?
@@ -64,7 +65,8 @@ export abstract class AsnData<T> implements TextObjectConvertible {
       this.#rawData = BufferSourceConverter.toArrayBuffer(args[0]);
       this.onInit(this.asn);
     } else {
-      // asn
+      // asn, options?
+      this.#options = args[1];
       this.asn = args[0];
       this.onInit(this.asn);
     }

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -3,6 +3,7 @@ import { Attribute as AsnAttribute } from "@peculiar/asn1-x509";
 import { BufferSourceConverter } from "pvtsutils";
 import { AsnData } from "./asn_data";
 import { OidSerializer, TextObject } from "./text_converter";
+import { ParseOptions } from "./types";
 
 /**
  * Represents the Attribute structure
@@ -29,12 +30,15 @@ export class Attribute extends AsnData<AsnAttribute> {
   /**
    * Crates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   public constructor(...args: any[]) {
     let raw: ArrayBuffer;
+    let options: ParseOptions | undefined;
     if (BufferSourceConverter.isBufferSource(args[0])) {
       raw = BufferSourceConverter.toArrayBuffer(args[0]);
+      options = args[1];
     } else {
       const type = args[0];
       const values = Array.isArray(args[1])
@@ -45,7 +49,7 @@ export class Attribute extends AsnData<AsnAttribute> {
       }));
     }
 
-    super(raw, AsnAttribute);
+    super(raw, AsnAttribute, options);
   }
 
   protected onInit(asn: AsnAttribute): void {

--- a/src/attributes/attribute_factory.ts
+++ b/src/attributes/attribute_factory.ts
@@ -1,4 +1,5 @@
 import { Attribute } from "../attribute";
+import { ParseOptions } from "../types";
 
 /**
  * Static class to manage X509 attributes
@@ -23,17 +24,18 @@ export class AttributeFactory {
   /**
    * Returns X509 Attribute based on it's identifier
    * @param data DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    *
    * @example
    * ```js
    * const attr = AttributeFactory.create(asnAttrRaw);
    * ```
    */
-  public static create(data: BufferSource) {
-    const attribute = new Attribute(data);
+  public static create(data: BufferSource, options?: ParseOptions) {
+    const attribute = new Attribute(data, options);
     const Type = this.items.get(attribute.type);
     if (Type) {
-      return new Type(data);
+      return new Type(data, options);
     }
 
     return attribute;

--- a/src/attributes/challenge.ts
+++ b/src/attributes/challenge.ts
@@ -4,6 +4,7 @@ import * as asnPkcs9 from "@peculiar/asn1-pkcs9";
 import { BufferSourceConverter } from "pvtsutils";
 import { Attribute } from "../attribute";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 export class ChallengePasswordAttribute extends Attribute {
   public static override NAME = "Challenge Password";
@@ -13,8 +14,9 @@ export class ChallengePasswordAttribute extends Attribute {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param value
@@ -22,7 +24,7 @@ export class ChallengePasswordAttribute extends Attribute {
   public constructor(value: string);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else {
       const value = new asnPkcs9.ChallengePassword({ printableString: args[0] });
       super(asnPkcs9.id_pkcs9_at_challengePassword, [AsnConvert.serialize(value)]);
@@ -35,7 +37,11 @@ export class ChallengePasswordAttribute extends Attribute {
     super.onInit(asn);
 
     if (this.values[0]) {
-      const value = AsnConvert.parse(this.values[0], asnPkcs9.ChallengePassword);
+      const value = AsnConvert.parse(
+        this.values[0],
+        asnPkcs9.ChallengePassword,
+        this.parseOptions,
+      );
       this.password = value.toString();
     }
   }

--- a/src/attributes/extensions.ts
+++ b/src/attributes/extensions.ts
@@ -6,6 +6,7 @@ import { Attribute } from "../attribute";
 import { Extension } from "../extension";
 import { ExtensionFactory } from "../extensions";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 export class ExtensionsAttribute extends Attribute {
   public static override NAME = "Extensions";
@@ -15,8 +16,9 @@ export class ExtensionsAttribute extends Attribute {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param extensions
@@ -24,7 +26,7 @@ export class ExtensionsAttribute extends Attribute {
   public constructor(extensions: Extension[]);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else {
       const extensions = args[0] as Extension[];
       const value = new asnX509.Extensions();
@@ -41,8 +43,10 @@ export class ExtensionsAttribute extends Attribute {
     super.onInit(asn);
 
     if (this.values[0]) {
-      const value = AsnConvert.parse(this.values[0], asnX509.Extensions);
-      this.items = value.map((o) => ExtensionFactory.create(AsnConvert.serialize(o)));
+      const value = AsnConvert.parse(this.values[0], asnX509.Extensions, this.parseOptions);
+      this.items = value.map((o) => (
+        ExtensionFactory.create(AsnConvert.serialize(o), this.parseOptions)
+      ));
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { Extension as AsnExtension } from "@peculiar/asn1-x509";
 import { BufferSourceConverter } from "pvtsutils";
 import { AsnData } from "./asn_data";
 import { OidSerializer, TextObject } from "./text_converter";
+import { ParseOptions } from "./types";
 
 /**
  * Represents the certificate extension
@@ -25,8 +26,9 @@ export class Extension extends AsnData<AsnExtension> {
   /**
    * Creates a new instance from DER encoded Buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param type Extension identifier
@@ -36,8 +38,10 @@ export class Extension extends AsnData<AsnExtension> {
   public constructor(type: string, critical: boolean, value: BufferSource);
   public constructor(...args: any[]) {
     let raw: ArrayBuffer;
+    let options: ParseOptions | undefined;
     if (BufferSourceConverter.isBufferSource(args[0])) {
       raw = BufferSourceConverter.toArrayBuffer(args[0]);
+      options = args[1];
     } else {
       raw = AsnConvert.serialize(new AsnExtension({
         extnID: args[0],
@@ -46,7 +50,7 @@ export class Extension extends AsnData<AsnExtension> {
       }));
     }
 
-    super(raw, AsnExtension);
+    super(raw, AsnExtension, options);
   }
 
   protected onInit(asn: AsnExtension) {

--- a/src/extensions/authority_info_access.ts
+++ b/src/extensions/authority_info_access.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { TextObject } from "../text_converter";
 import { GeneralName } from "../general_name";
+import { ParseOptions } from "../types";
 
 export type AccessItemTypes = GeneralName | GeneralName[] | string | string[];
 export interface AuthorityInfoAccessParams {
@@ -27,8 +28,9 @@ export class AuthorityInfoAccessExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param value The value of the extension
@@ -43,7 +45,7 @@ export class AuthorityInfoAccessExtension extends Extension {
   public constructor(params: AuthorityInfoAccessParams, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else if (args[0] instanceof asn1X509.AuthorityInfoAccessSyntax) {
       const value = new asn1X509.AuthorityInfoAccessSyntax(args[0]);
       super(asn1X509.id_pe_authorityInfoAccess, args[1], AsnConvert.serialize(value));
@@ -73,7 +75,11 @@ export class AuthorityInfoAccessExtension extends Extension {
     this.timeStamping = [];
     this.caRepository = [];
 
-    const aia = AsnConvert.parse(asn.extnValue, asn1X509.AuthorityInfoAccessSyntax);
+    const aia = AsnConvert.parse(
+      asn.extnValue,
+      asn1X509.AuthorityInfoAccessSyntax,
+      this.parseOptions,
+    );
     aia.forEach((accessDescription) => {
       switch (accessDescription.accessMethod) {
         case asn1X509.id_ad_ocsp:

--- a/src/extensions/authority_key_identifier.ts
+++ b/src/extensions/authority_key_identifier.ts
@@ -6,6 +6,7 @@ import { GeneralNames } from "../general_name";
 import { cryptoProvider } from "../provider";
 import { PublicKey, PublicKeyType } from "../public_key";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 export interface CertificateIdentifier {
   /**
@@ -73,8 +74,9 @@ export class AuthorityKeyIdentifierExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param identifier Hexadecimal representation of key identifier
@@ -89,7 +91,7 @@ export class AuthorityKeyIdentifierExtension extends Extension {
   public constructor(id: CertificateIdentifier, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else if (typeof args[0] === "string") {
       const value = new asn1X509.AuthorityKeyIdentifier(
         { keyIdentifier: new asn1X509.KeyIdentifier(Convert.FromHex(args[0])) },
@@ -111,7 +113,11 @@ export class AuthorityKeyIdentifierExtension extends Extension {
   protected onInit(asn: asn1X509.Extension) {
     super.onInit(asn);
 
-    const aki = AsnConvert.parse(asn.extnValue, asn1X509.AuthorityKeyIdentifier);
+    const aki = AsnConvert.parse(
+      asn.extnValue,
+      asn1X509.AuthorityKeyIdentifier,
+      this.parseOptions,
+    );
     if (aki.keyIdentifier) {
       this.keyId = Convert.ToHex(aki.keyIdentifier);
     }
@@ -127,7 +133,7 @@ export class AuthorityKeyIdentifierExtension extends Extension {
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectWithoutValue();
 
-    const asn = AsnConvert.parse(this.value, asn1X509.AuthorityKeyIdentifier);
+    const asn = AsnConvert.parse(this.value, asn1X509.AuthorityKeyIdentifier, this.parseOptions);
 
     if (asn.authorityCertIssuer) {
       obj["Authority Issuer"] = new GeneralNames(asn.authorityCertIssuer).toTextObject();

--- a/src/extensions/basic_constraints.ts
+++ b/src/extensions/basic_constraints.ts
@@ -3,6 +3,7 @@ import { BasicConstraints as AsnBasicConstraints, id_ce_basicConstraints } from 
 import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 /**
  * Represents the Basic Constraints certificate extension
@@ -25,8 +26,9 @@ export class BasicConstraintsExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param ca
@@ -36,9 +38,9 @@ export class BasicConstraintsExtension extends Extension {
   public constructor(ca: boolean, pathLength?: number, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
 
-      const value = AsnConvert.parse(this.value, AsnBasicConstraints);
+      const value = AsnConvert.parse(this.value, AsnBasicConstraints, this.parseOptions);
       this.ca = value.cA;
       this.pathLength = value.pathLenConstraint;
     } else {

--- a/src/extensions/certificate_policy.ts
+++ b/src/extensions/certificate_policy.ts
@@ -3,6 +3,7 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { OidSerializer, TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 import { ExtensionFactory } from "./extension_factory";
 
 /**
@@ -19,8 +20,9 @@ export class CertificatePolicyExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  constructor(raw: BufferSource);
+  constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param policies
@@ -29,9 +31,13 @@ export class CertificatePolicyExtension extends Extension {
   constructor(policies: string[], critical?: boolean);
   constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
 
-      const asnPolicies = AsnConvert.parse(this.value, asnX509.CertificatePolicies);
+      const asnPolicies = AsnConvert.parse(
+        this.value,
+        asnX509.CertificatePolicies,
+        this.parseOptions,
+      );
       this.policies = asnPolicies.map((o) => o.policyIdentifier);
     } else {
       const policies = args[0] as string[];

--- a/src/extensions/crl_distribution_points.ts
+++ b/src/extensions/crl_distribution_points.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { TextObject } from "../text_converter";
 import { GeneralName } from "../general_name";
+import { ParseOptions } from "../types";
 
 /**
  * Represents the CRL Distribution Points extension
@@ -16,8 +17,9 @@ export class CRLDistributionPointsExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param value The value of the extension
@@ -32,7 +34,7 @@ export class CRLDistributionPointsExtension extends Extension {
   public constructor(urls: string[], critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else if (Array.isArray(args[0]) && typeof args[0][0] === "string") {
       const urls = args[0] as string[];
       const dps = urls.map((url) => {
@@ -55,7 +57,11 @@ export class CRLDistributionPointsExtension extends Extension {
   protected onInit(asn: asn1X509.Extension) {
     super.onInit(asn);
 
-    const crlExt = AsnConvert.parse(asn.extnValue, asn1X509.CRLDistributionPoints);
+    const crlExt = AsnConvert.parse(
+      asn.extnValue,
+      asn1X509.CRLDistributionPoints,
+      this.parseOptions,
+    );
     this.distributionPoints = crlExt;
   }
 

--- a/src/extensions/extended_key_usage.ts
+++ b/src/extensions/extended_key_usage.ts
@@ -3,6 +3,7 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { OidSerializer, TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 export enum ExtendedKeyUsage {
   serverAuth = "1.3.6.1.5.5.7.3.1",
@@ -28,8 +29,9 @@ export class ExtendedKeyUsageExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param usages
@@ -38,9 +40,9 @@ export class ExtendedKeyUsageExtension extends Extension {
   public constructor(usages: ExtendedKeyUsageType[], critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
 
-      const value = AsnConvert.parse(this.value, asn1X509.ExtendedKeyUsage);
+      const value = AsnConvert.parse(this.value, asn1X509.ExtendedKeyUsage, this.parseOptions);
       this.usages = value.map((o) => o);
     } else {
       const value = new asn1X509.ExtendedKeyUsage(args[0]);

--- a/src/extensions/extension_factory.ts
+++ b/src/extensions/extension_factory.ts
@@ -1,4 +1,5 @@
 import { Extension } from "../extension";
+import { ParseOptions } from "../types";
 
 /**
  * Static class to manage X509 extensions
@@ -26,17 +27,18 @@ export class ExtensionFactory {
   /**
    * Returns X509 Extension based on it's identifier
    * @param data DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    *
    * @example
    * ```js
    * const ext = ExtensionFactory.create(asnExtRaw);
    * ```
    */
-  public static create(data: BufferSource) {
-    const extension = new Extension(data);
+  public static create(data: BufferSource, options?: ParseOptions) {
+    const extension = new Extension(data, options);
     const Type = this.items.get(extension.type);
     if (Type) {
-      return new Type(data);
+      return new Type(data, options);
     }
 
     return extension;

--- a/src/extensions/issuer_alt_name.ts
+++ b/src/extensions/issuer_alt_name.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { GeneralNames, JsonGeneralNames } from "../general_name";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 /**
  * Represents the Issuer Alternative Name certificate extension
@@ -16,8 +17,9 @@ export class IssuerAlternativeNameExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param data JSON representation of IAN
@@ -26,7 +28,7 @@ export class IssuerAlternativeNameExtension extends Extension {
   public constructor(data?: JsonGeneralNames, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else {
       super(asn1X509.id_ce_issuerAltName, args[1], new GeneralNames(args[0] || []).rawData);
     }
@@ -35,7 +37,7 @@ export class IssuerAlternativeNameExtension extends Extension {
   onInit(asn: asn1X509.Extension) {
     super.onInit(asn);
     // value
-    const value = AsnConvert.parse(asn.extnValue, asn1X509.GeneralNames);
+    const value = AsnConvert.parse(asn.extnValue, asn1X509.GeneralNames, this.parseOptions);
     this.names = new GeneralNames(value);
   }
 

--- a/src/extensions/key_usages.ts
+++ b/src/extensions/key_usages.ts
@@ -3,6 +3,7 @@ import { id_ce_keyUsage, KeyUsage } from "@peculiar/asn1-x509";
 import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 /**
  * X509 key usages flags
@@ -33,8 +34,9 @@ export class KeyUsagesExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param usages
@@ -43,9 +45,9 @@ export class KeyUsagesExtension extends Extension {
   public constructor(usages: KeyUsageFlags, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
 
-      const value = AsnConvert.parse(this.value, KeyUsage);
+      const value = AsnConvert.parse(this.value, KeyUsage, this.parseOptions);
       this.usages = value.toNumber();
     } else {
       const value = new KeyUsage(args[0]);
@@ -58,7 +60,7 @@ export class KeyUsagesExtension extends Extension {
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectWithoutValue();
 
-    const asn = AsnConvert.parse(this.value, KeyUsage);
+    const asn = AsnConvert.parse(this.value, KeyUsage, this.parseOptions);
 
     obj[""] = asn.toJSON().join(", ");
 

--- a/src/extensions/subject_alt_name.ts
+++ b/src/extensions/subject_alt_name.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { Extension } from "../extension";
 import { GeneralNames, JsonGeneralNames } from "../general_name";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 /**
  * Represents the Subject Alternative Name certificate extension
@@ -16,8 +17,9 @@ export class SubjectAlternativeNameExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param data JSON representation of SAN
@@ -26,7 +28,7 @@ export class SubjectAlternativeNameExtension extends Extension {
   public constructor(data?: JsonGeneralNames, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
     } else {
       super(asn1X509.id_ce_subjectAltName, args[1], new GeneralNames(args[0] || []).rawData);
     }
@@ -36,7 +38,11 @@ export class SubjectAlternativeNameExtension extends Extension {
     super.onInit(asn);
 
     // value
-    const value = AsnConvert.parse(asn.extnValue, asn1X509.SubjectAlternativeName);
+    const value = AsnConvert.parse(
+      asn.extnValue,
+      asn1X509.SubjectAlternativeName,
+      this.parseOptions,
+    );
 
     this.names = new GeneralNames(value);
   }

--- a/src/extensions/subject_key_identifier.ts
+++ b/src/extensions/subject_key_identifier.ts
@@ -5,6 +5,7 @@ import { Extension } from "../extension";
 import { cryptoProvider } from "../provider";
 import { PublicKey, PublicKeyType } from "../public_key";
 import { TextObject } from "../text_converter";
+import { ParseOptions } from "../types";
 
 /**
  * Represents the Subject Key Identifier certificate extension
@@ -37,8 +38,9 @@ export class SubjectKeyIdentifierExtension extends Extension {
   /**
    * Creates a new instance from DER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param keyId Hexadecimal representation of key identifier
@@ -47,9 +49,9 @@ export class SubjectKeyIdentifierExtension extends Extension {
   public constructor(keyId: string, critical?: boolean);
   public constructor(...args: any[]) {
     if (BufferSourceConverter.isBufferSource(args[0])) {
-      super(args[0] as BufferSource);
+      super(args[0] as BufferSource, args[1] as ParseOptions | undefined);
 
-      const value = AsnConvert.parse(this.value, asn1X509.SubjectKeyIdentifier);
+      const value = AsnConvert.parse(this.value, asn1X509.SubjectKeyIdentifier, this.parseOptions);
       this.keyId = Convert.ToHex(value);
     } else {
       const identifier = typeof args[0] === "string"
@@ -65,7 +67,7 @@ export class SubjectKeyIdentifierExtension extends Extension {
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectWithoutValue();
 
-    const asn = AsnConvert.parse(this.value, asn1X509.SubjectKeyIdentifier);
+    const asn = AsnConvert.parse(this.value, asn1X509.SubjectKeyIdentifier, this.parseOptions);
 
     obj[""] = asn;
 

--- a/src/pem_data.ts
+++ b/src/pem_data.ts
@@ -1,5 +1,6 @@
 import { BufferSourceConverter, Convert } from "pvtsutils";
 import { AsnData, AsnDataStringFormat } from "./asn_data";
+import { ParseOptions } from "./types";
 import { PemConverter } from "./pem_converter";
 
 export type AsnExportType = "pem" | AsnDataStringFormat;
@@ -61,7 +62,7 @@ export abstract class PemData<T> extends AsnData<T> {
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
    * @param type ASN.1 convertible class for `@peculiar/asn1-schema` schema
    */
-  public constructor(raw: AsnEncodedType, type: new() => T);
+  public constructor(raw: AsnEncodedType, type: new() => T, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param asn ASN.1 object
@@ -69,7 +70,7 @@ export abstract class PemData<T> extends AsnData<T> {
   public constructor(asn: T);
   public constructor(...args: any[]) {
     if (PemData.isAsnEncoded(args[0])) {
-      super(PemData.toArrayBuffer(args[0]), args[1]);
+      super(PemData.toArrayBuffer(args[0]), args[1], args[2]);
     } else {
       super(args[0]);
     }

--- a/src/pem_data.ts
+++ b/src/pem_data.ts
@@ -66,13 +66,14 @@ export abstract class PemData<T> extends AsnData<T> {
   /**
    * Creates a new instance
    * @param asn ASN.1 object
+   * @param options ASN.1 parse options used for nested ASN.1 payloads
    */
-  public constructor(asn: T);
+  public constructor(asn: T, options?: ParseOptions);
   public constructor(...args: any[]) {
     if (PemData.isAsnEncoded(args[0])) {
       super(PemData.toArrayBuffer(args[0]), args[1], args[2]);
     } else {
-      super(args[0]);
+      super(args[0], args[1]);
     }
   }
 

--- a/src/pkcs10_cert_req.ts
+++ b/src/pkcs10_cert_req.ts
@@ -5,7 +5,7 @@ import { container } from "tsyringe";
 import { Version } from "@peculiar/asn1-x509";
 import { Name } from "./name";
 import { cryptoProvider } from "./provider";
-import { HashedAlgorithm } from "./types";
+import { HashedAlgorithm, ParseOptions } from "./types";
 import { Attribute } from "./attribute";
 import { Extension } from "./extension";
 import { IPublicKeyContainer, PublicKey } from "./public_key";
@@ -165,16 +165,17 @@ export class Pkcs10CertificateRequest extends PemData<CertificationRequest>
   /**
    * Creates a new instance fromDER encoded buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: AsnEncodedType);
+  public constructor(raw: AsnEncodedType, options?: ParseOptions);
   /**
    * Creates a new instance from ASN.1 CertificationRequest
    * @param asn ASN.1 CertificationRequest
    */
   public constructor(asn: CertificationRequest);
-  public constructor(param: AsnEncodedType | CertificationRequest) {
-    const args = PemData.isAsnEncoded(param) ? [param, CertificationRequest] : [param];
-    super(args[0] as any, args[1] as any);
+  public constructor(param: AsnEncodedType | CertificationRequest, options?: ParseOptions) {
+    const args = PemData.isAsnEncoded(param) ? [param, CertificationRequest, options] : [param];
+    super(args[0] as any, args[1] as any, args[2] as any);
     this.tag = PemConverter.CertificateRequestTag;
   }
 
@@ -261,7 +262,7 @@ export class Pkcs10CertificateRequest extends PemData<CertificationRequest>
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectEmpty();
 
-    const req = AsnConvert.parse(this.rawData, CertificationRequest);
+    const req = AsnConvert.parse(this.rawData, CertificationRequest, this.parseOptions);
 
     const tbs = req.certificationRequestInfo;
     const data = new TextObject("", {

--- a/src/pkcs10_cert_req.ts
+++ b/src/pkcs10_cert_req.ts
@@ -117,7 +117,10 @@ export class Pkcs10CertificateRequest extends PemData<CertificationRequest>
    */
   public get publicKey(): PublicKey {
     if (!this.#publicKey) {
-      this.#publicKey = new PublicKey(this.asn.certificationRequestInfo.subjectPKInfo);
+      this.#publicKey = new PublicKey(
+        this.asn.certificationRequestInfo.subjectPKInfo,
+        this.parseOptions,
+      );
     }
 
     return this.#publicKey;
@@ -129,7 +132,7 @@ export class Pkcs10CertificateRequest extends PemData<CertificationRequest>
   public get attributes(): Attribute[] {
     if (!this.#attributes) {
       this.#attributes = this.asn.certificationRequestInfo.attributes
-        .map((o) => AttributeFactory.create(AsnConvert.serialize(o)));
+        .map((o) => AttributeFactory.create(AsnConvert.serialize(o), this.parseOptions));
     }
 
     return this.#attributes;
@@ -171,10 +174,13 @@ export class Pkcs10CertificateRequest extends PemData<CertificationRequest>
   /**
    * Creates a new instance from ASN.1 CertificationRequest
    * @param asn ASN.1 CertificationRequest
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(asn: CertificationRequest);
+  public constructor(asn: CertificationRequest, options?: ParseOptions);
   public constructor(param: AsnEncodedType | CertificationRequest, options?: ParseOptions) {
-    const args = PemData.isAsnEncoded(param) ? [param, CertificationRequest, options] : [param];
+    const args = PemData.isAsnEncoded(param)
+      ? [param, CertificationRequest, options]
+      : [param, options];
     super(args[0] as any, args[1] as any, args[2] as any);
     this.tag = PemConverter.CertificateRequestTag;
   }

--- a/src/public_key.ts
+++ b/src/public_key.ts
@@ -11,6 +11,7 @@ import { PemConverter } from "./pem_converter";
 import { AsnEncodedType, PemData } from "./pem_data";
 import { CryptoProvider, cryptoProvider } from "./provider";
 import { TextConverter, TextObject } from "./text_converter";
+import { ParseOptions } from "./types";
 
 export interface IPublicKeyContainer {
   publicKey: PublicKey;
@@ -67,11 +68,15 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: AsnEncodedType);
-  public constructor(param: AsnEncodedType | SubjectPublicKeyInfo) {
+  public constructor(raw: AsnEncodedType, options?: ParseOptions);
+  public constructor(
+    param: AsnEncodedType | SubjectPublicKeyInfo,
+    options?: ParseOptions,
+  ) {
     if (PemData.isAsnEncoded(param)) {
-      super(param, SubjectPublicKeyInfo);
+      super(param, SubjectPublicKeyInfo, options);
     } else {
       super(param);
     }
@@ -118,7 +123,7 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
     crypto ??= cryptoProvider.get();
 
     let raw = this.rawData;
-    const asnSpki = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo);
+    const asnSpki = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo, this.parseOptions);
     if (asnSpki.algorithm.algorithm === id_RSASSA_PSS) {
       // WebCrypto in browsers does not support RSA-PSS algorithm for public keys
       // So, we need to convert it to RSA-PKCS1
@@ -213,7 +218,7 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
     // value of the BIT STRING subjectPublicKey (excluding the tag,
     // length, and number of unused bits).
 
-    const asn = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo);
+    const asn = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo, this.parseOptions);
 
     return await crypto.subtle.digest(algorithm, asn.subjectPublicKey);
   }
@@ -221,7 +226,7 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectEmpty();
 
-    const asn = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo);
+    const asn = AsnConvert.parse(this.rawData, SubjectPublicKeyInfo, this.parseOptions);
 
     obj["Algorithm"] = TextConverter.serializeAlgorithm(asn.algorithm);
 

--- a/src/public_key.ts
+++ b/src/public_key.ts
@@ -63,8 +63,9 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
   /**
    * Creates a new instance from ASN.1
    * @param asn ASN.1 object
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(asn: SubjectPublicKeyInfo);
+  public constructor(asn: SubjectPublicKeyInfo, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
@@ -78,7 +79,7 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
     if (PemData.isAsnEncoded(param)) {
       super(param, SubjectPublicKeyInfo, options);
     } else {
-      super(param);
+      super(param, options);
     }
 
     this.tag = PemConverter.PublicKeyTag;
@@ -140,7 +141,11 @@ export class PublicKey extends PemData<SubjectPublicKeyInfo> {
     switch (asn.algorithm.algorithm) {
       case id_rsaEncryption:
       {
-        const rsaPublicKey = AsnConvert.parse(asn.subjectPublicKey, RSAPublicKey);
+        const rsaPublicKey = AsnConvert.parse(
+          asn.subjectPublicKey,
+          RSAPublicKey,
+          this.parseOptions,
+        );
         const modulus = BufferSourceConverter.toUint8Array(rsaPublicKey.modulus);
         algorithm.publicExponent = BufferSourceConverter.toUint8Array(rsaPublicKey.publicExponent);
         algorithm.modulusLength = (!modulus[0] ? modulus.slice(1) : modulus).byteLength << 3;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,12 @@
+import { IAsnParseOptions } from "@peculiar/asn1-schema";
+
 export interface HashedAlgorithm extends Algorithm {
   hash: Algorithm;
 }
+
+/**
+ * Options for parsing ASN.1 encoded data. Forwards `asn1js.fromBER` resource
+ * limits (`maxDepth`, `maxNodes`, `maxContentLength` via `berOptions`) so callers
+ * can tune them when parsing untrusted input.
+ */
+export type ParseOptions = IAsnParseOptions;

--- a/src/x509_cert.ts
+++ b/src/x509_cert.ts
@@ -2,7 +2,7 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import { Certificate, Version } from "@peculiar/asn1-x509";
 import { BufferSourceConverter, Convert } from "pvtsutils";
 import { container } from "tsyringe";
-import { HashedAlgorithm } from "./types";
+import { HashedAlgorithm, ParseOptions } from "./types";
 import { cryptoProvider } from "./provider";
 import { Name } from "./name";
 import { Extension } from "./extension";
@@ -264,11 +264,12 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: AsnEncodedType);
-  public constructor(param: AsnEncodedType | Certificate) {
-    const args = PemData.isAsnEncoded(param) ? [param, Certificate] : [param];
-    super(args[0] as any, args[1] as any);
+  public constructor(raw: AsnEncodedType, options?: ParseOptions);
+  public constructor(param: AsnEncodedType | Certificate, options?: ParseOptions) {
+    const args = PemData.isAsnEncoded(param) ? [param, Certificate, options] : [param];
+    super(args[0] as any, args[1] as any, args[2] as any);
 
     this.tag = PemConverter.CertificateTag;
   }
@@ -449,7 +450,7 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
   public override toTextObject(): TextObject {
     const obj = this.toTextObjectEmpty();
 
-    const cert = AsnConvert.parse(this.rawData, Certificate);
+    const cert = AsnConvert.parse(this.rawData, Certificate, this.parseOptions);
 
     const tbs = cert.tbsCertificate;
     const data = new TextObject("", {

--- a/src/x509_cert.ts
+++ b/src/x509_cert.ts
@@ -98,7 +98,10 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
    */
   public get publicKey(): PublicKey {
     if (!this.#publicKey) {
-      this.#publicKey = new PublicKey(this.asn.tbsCertificate.subjectPublicKeyInfo);
+      this.#publicKey = new PublicKey(
+        this.asn.tbsCertificate.subjectPublicKeyInfo,
+        this.parseOptions,
+      );
     }
 
     return this.#publicKey;
@@ -232,7 +235,7 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
       this.#extensions = [];
       if (this.asn.tbsCertificate.extensions) {
         this.#extensions = this.asn.tbsCertificate.extensions.map((o) => (
-          ExtensionFactory.create(AsnConvert.serialize(o))
+          ExtensionFactory.create(AsnConvert.serialize(o), this.parseOptions)
         ));
       }
     }
@@ -259,8 +262,9 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
   /**
    * Creates a new instance from ASN.1 Certificate object
    * @param asn ASN.1 Certificate object
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(asn: Certificate);
+  public constructor(asn: Certificate, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
@@ -268,7 +272,9 @@ export class X509Certificate extends PemData<Certificate> implements IPublicKeyC
    */
   public constructor(raw: AsnEncodedType, options?: ParseOptions);
   public constructor(param: AsnEncodedType | Certificate, options?: ParseOptions) {
-    const args = PemData.isAsnEncoded(param) ? [param, Certificate, options] : [param];
+    const args = PemData.isAsnEncoded(param)
+      ? [param, Certificate, options]
+      : [param, options];
     super(args[0] as any, args[1] as any, args[2] as any);
 
     this.tag = PemConverter.CertificateTag;

--- a/src/x509_certs.ts
+++ b/src/x509_certs.ts
@@ -10,6 +10,7 @@ import {
   OidSerializer, TextConverter, TextObject, TextObjectConvertible,
 } from "./text_converter";
 import { X509Certificate } from "./x509_cert";
+import { ParseOptions } from "./types";
 
 export type X509CertificatesExportType = AsnExportType | "pem-chain";
 
@@ -18,14 +19,20 @@ export type X509CertificatesExportType = AsnExportType | "pem-chain";
  */
 export class X509Certificates extends Array<X509Certificate> implements TextObjectConvertible {
   /**
+   * ASN.1 parse options
+   */
+  #options?: ParseOptions;
+
+  /**
    * Creates a new instance
    */
   public constructor();
   /**
    * Creates a new instance from encoded PKCS7 buffer
    * @param raw Encoded PKCS7 buffer. Supported formats are DER, PEM, HEX, Base64, or Base64Url
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: AsnEncodedType);
+  public constructor(raw: AsnEncodedType, options?: ParseOptions);
   /**
    * Creates a new instance form X509 certificate
    * @param cert X509 certificate
@@ -36,11 +43,14 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
    * @param certs List of x509 certificates
    */
   public constructor(certs: X509Certificate[]);
-  public constructor(param?: AsnEncodedType | X509Certificate | X509Certificate[]) {
+  public constructor(
+    param?: AsnEncodedType | X509Certificate | X509Certificate[],
+    options?: ParseOptions,
+  ) {
     super();
 
     if (PemData.isAsnEncoded(param)) {
-      this.import(param);
+      this.import(param, options);
     } else if (param instanceof X509Certificate) {
       this.push(param);
     } else if (Array.isArray(param)) {
@@ -95,15 +105,17 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
    * Import certificates from encoded PKCS7 data. Supported formats are HEX, DER,
    * Base64, Base64Url, PEM
    * @param data
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public import(data: AsnEncodedType) {
+  public import(data: AsnEncodedType, options?: ParseOptions) {
+    this.#options = options;
     const raw = PemData.toArrayBuffer(data);
-    const cms = AsnConvert.parse(raw, asn1Cms.ContentInfo);
+    const cms = AsnConvert.parse(raw, asn1Cms.ContentInfo, options);
     if (cms.contentType !== asn1Cms.id_signedData) {
       throw new TypeError("Cannot parse CMS package. Incoming data is not a SignedData object.");
     }
 
-    const signedData = AsnConvert.parse(cms.content, asn1Cms.SignedData);
+    const signedData = AsnConvert.parse(cms.content, asn1Cms.SignedData, options);
     this.clear();
 
     for (const item of signedData.certificates || []) {
@@ -132,7 +144,7 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
           .map((o) => o.toString("pem"))
           .join("\n");
       case "asn":
-        return AsnConvert.toString(raw);
+        return AsnConvert.toString(raw, this.#options);
       case "hex":
         return Convert.ToHex(raw);
       case "base64":
@@ -147,8 +159,8 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
   }
 
   public toTextObject(): TextObject {
-    const contentInfo = AsnConvert.parse(this.export("raw"), asn1Cms.ContentInfo);
-    const signedData = AsnConvert.parse(contentInfo.content, asn1Cms.SignedData);
+    const contentInfo = AsnConvert.parse(this.export("raw"), asn1Cms.ContentInfo, this.#options);
+    const signedData = AsnConvert.parse(contentInfo.content, asn1Cms.SignedData, this.#options);
 
     const obj = new TextObject("X509Certificates", {
       "Content Type": OidSerializer.toString(contentInfo.contentType),

--- a/src/x509_certs.ts
+++ b/src/x509_certs.ts
@@ -108,7 +108,6 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
    * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
   public import(data: AsnEncodedType, options?: ParseOptions) {
-    this.#options = options;
     const raw = PemData.toArrayBuffer(data);
     const cms = AsnConvert.parse(raw, asn1Cms.ContentInfo, options);
     if (cms.contentType !== asn1Cms.id_signedData) {
@@ -116,13 +115,20 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
     }
 
     const signedData = AsnConvert.parse(cms.content, asn1Cms.SignedData, options);
-    this.clear();
-
+    const certificates: X509Certificate[] = [];
     for (const item of signedData.certificates || []) {
       if (item.certificate) {
-        this.push(new X509Certificate(item.certificate, options));
+        certificates.push(new X509Certificate(item.certificate, options));
       }
     }
+
+    // Replace the collection only once everything has been parsed, so a failed
+    // import leaves the current certificates and parse options untouched
+    this.clear();
+    for (const certificate of certificates) {
+      this.push(certificate);
+    }
+    this.#options = options;
   }
 
   /**

--- a/src/x509_certs.ts
+++ b/src/x509_certs.ts
@@ -84,7 +84,7 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
     );
     signedData.certificates = new asn1Cms.CertificateSet(
       this.map((o) => new asn1Cms.CertificateChoices(
-        { certificate: AsnConvert.parse(o.rawData, Certificate) }),
+        { certificate: AsnConvert.parse(o.rawData, Certificate, this.#options) }),
       ),
     );
 
@@ -120,7 +120,7 @@ export class X509Certificates extends Array<X509Certificate> implements TextObje
 
     for (const item of signedData.certificates || []) {
       if (item.certificate) {
-        this.push(new X509Certificate(item.certificate));
+        this.push(new X509Certificate(item.certificate, options));
       }
     }
   }

--- a/src/x509_crl.ts
+++ b/src/x509_crl.ts
@@ -4,7 +4,7 @@ import {
 } from "@peculiar/asn1-x509";
 import { BufferSourceConverter } from "pvtsutils";
 import { container } from "tsyringe";
-import { HashedAlgorithm } from "./types";
+import { HashedAlgorithm, ParseOptions } from "./types";
 import { cryptoProvider } from "./provider";
 import { Name } from "./name";
 import { Extension } from "./extension";
@@ -202,11 +202,12 @@ export class X509Crl extends PemData<CertificateList> {
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: AsnEncodedType);
-  public constructor(param: AsnEncodedType | CertificateList) {
+  public constructor(raw: AsnEncodedType, options?: ParseOptions);
+  public constructor(param: AsnEncodedType | CertificateList, options?: ParseOptions) {
     // @ts-expect-error: super call with private fields
-    super(param, PemData.isAsnEncoded(param) ? CertificateList : undefined);
+    super(param, PemData.isAsnEncoded(param) ? CertificateList : undefined, options);
   }
 
   protected onInit(_asn: CertificateList) {

--- a/src/x509_crl.ts
+++ b/src/x509_crl.ts
@@ -147,7 +147,7 @@ export class X509Crl extends PemData<CertificateList> {
   public get entries(): readonly X509CrlEntry[] {
     if (!this.#entries) {
       this.#entries = this.asn.tbsCertList
-        .revokedCertificates?.map((o) => new X509CrlEntry(o)) || [];
+        .revokedCertificates?.map((o) => new X509CrlEntry(o, this.parseOptions)) || [];
     }
 
     return this.#entries;
@@ -161,7 +161,7 @@ export class X509Crl extends PemData<CertificateList> {
       this.#extensions = [];
       if (this.asn.tbsCertList.crlExtensions) {
         this.#extensions = this.asn.tbsCertList.crlExtensions.map((o) =>
-          ExtensionFactory.create(AsnConvert.serialize(o)),
+          ExtensionFactory.create(AsnConvert.serialize(o), this.parseOptions),
         );
       }
     }
@@ -197,8 +197,9 @@ export class X509Crl extends PemData<CertificateList> {
   /**
    * Creates a new instance from ASN.1 CertificateList object
    * @param asn ASN.1 CertificateList object
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(asn: CertificateList);
+  public constructor(asn: CertificateList, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param raw Encoded buffer (DER, PEM, HEX, Base64, Base64Url)
@@ -206,8 +207,10 @@ export class X509Crl extends PemData<CertificateList> {
    */
   public constructor(raw: AsnEncodedType, options?: ParseOptions);
   public constructor(param: AsnEncodedType | CertificateList, options?: ParseOptions) {
-    // @ts-expect-error: super call with private fields
-    super(param, PemData.isAsnEncoded(param) ? CertificateList : undefined, options);
+    const args = PemData.isAsnEncoded(param)
+      ? [param, CertificateList, options]
+      : [param, options];
+    super(args[0] as any, args[1] as any, args[2] as any);
   }
 
   protected onInit(_asn: CertificateList) {
@@ -386,7 +389,7 @@ export class X509Crl extends PemData<CertificateList> {
     const serialBuffer = generateCertificateSerialNumber(serialNumber, crypto);
     for (const revoked of this.asn.tbsCertList.revokedCertificates || []) {
       if (BufferSourceConverter.isEqual(revoked.userCertificate, serialBuffer)) {
-        return new X509CrlEntry(AsnConvert.serialize(revoked));
+        return new X509CrlEntry(AsnConvert.serialize(revoked), this.parseOptions);
       }
     }
 

--- a/src/x509_crl_entry.ts
+++ b/src/x509_crl_entry.ts
@@ -7,6 +7,7 @@ import { Extension } from "./extension";
 import { ExtensionFactory } from "./extensions/extension_factory";
 import { AsnData } from "./asn_data";
 import { generateCertificateSerialNumber } from "./utils";
+import { ParseOptions } from "./types";
 
 /**
  * Reason Code
@@ -112,18 +113,20 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
       this.#extensions = [];
       if (this.asn.crlEntryExtensions) {
         this.#extensions = this.asn.crlEntryExtensions.map((o) => {
-          const extension = ExtensionFactory.create(AsnConvert.serialize(o));
+          const extension = ExtensionFactory.create(AsnConvert.serialize(o), this.parseOptions);
 
           switch (extension.type) {
             case id_ce_cRLReasons:
               if (this.#reason === undefined) {
                 this.#reason = AsnConvert
-                  .parse(extension.value, CRLReason).reason as unknown as X509CrlReason;
+                  .parse(extension.value, CRLReason, this.parseOptions)
+                  .reason as unknown as X509CrlReason;
               }
               break;
             case id_ce_invalidityDate:
               if (this.#invalidity === undefined) {
-                this.#invalidity = AsnConvert.parse(extension.value, InvalidityDate).value;
+                this.#invalidity = AsnConvert
+                  .parse(extension.value, InvalidityDate, this.parseOptions).value;
               }
               break;
           }
@@ -139,13 +142,15 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
   /**
    * Creates a new instance from DER encoded Buffer
    * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(raw: BufferSource);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   /**
    * Creates a new instance from ASN.1 object
    * @param asn ASN.1 object
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
    */
-  public constructor(asn: RevokedCertificate);
+  public constructor(asn: RevokedCertificate, options?: ParseOptions);
   /**
    * Creates a new instance
    * @param serialNumber Serial number of certificate
@@ -155,8 +160,10 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
   public constructor(serialNumber: string, revocationDate: Date, extensions: Extension[]);
   public constructor(...args: any[]) {
     let raw: ArrayBuffer | RevokedCertificate | undefined;
+    let options: ParseOptions | undefined;
     if (BufferSourceConverter.isBufferSource(args[0])) {
       raw = BufferSourceConverter.toArrayBuffer(args[0]);
+      options = args[1];
     } else if (typeof args[0] === "string") {
       raw = AsnConvert.serialize(new RevokedCertificate({
         userCertificate: generateCertificateSerialNumber(args[0]),
@@ -165,14 +172,17 @@ export class X509CrlEntry extends AsnData<RevokedCertificate> {
       }));
     } else if (args[0] instanceof RevokedCertificate) {
       raw = args[0];
+      options = args[1];
     }
 
     if (!raw) {
       throw new TypeError("Cannot create X509CrlEntry instance. Wrong constructor arguments.");
     }
 
-    // @ts-expect-error : next line is ok
-    super(raw, RevokedCertificate);
+    const superArgs = raw instanceof RevokedCertificate
+      ? [raw, options]
+      : [raw, RevokedCertificate, options];
+    super(superArgs[0] as any, superArgs[1] as any, superArgs[2] as any);
   }
 
   protected onInit(_asn: RevokedCertificate) {

--- a/test/parse_options.ts
+++ b/test/parse_options.ts
@@ -1,0 +1,126 @@
+import {
+  describe, it, expect, beforeAll,
+} from "vitest";
+import { Crypto } from "@peculiar/webcrypto";
+import { Convert } from "pvtsutils";
+import * as x509 from "../src";
+
+const crypto = new Crypto();
+x509.cryptoProvider.set(crypto);
+
+// https://github.com/PeculiarVentures/asn1-schema/pull/135
+// Exposes `asn1js.fromBER` resource limits (maxDepth/maxNodes/maxContentLength)
+// through `ParseOptions` so callers can tune them for untrusted input.
+describe("parse options (berOptions)", () => {
+  const certPem = [
+    "-----BEGIN CERTIFICATE-----",
+    "MIIDQzCCAuugAwIBAgICARYwCQYHKoZIzj0EATCBjjELMAkGA1UEBhMCUlUxDzAN",
+    "BgNVBAgTBlJ1c3NpYTEPMA0GA1UEBxMGTW9zY293MRcwFQYDVQQKEw5GU1VFIFNU",
+    "QyBBdGxhczENMAsGA1UECxMEVVpJUzEUMBIGA1UEAxMLQ1NDQS1SdXNzaWExHzAd",
+    "BgkqhkiG9w0BCQEWEGNhbWFpbEBzdGNuZXQucnUwHhcNMjIwMjI4MTA0MjQ2WhcN",
+    "MzQwMjI1MTA0MjQ2WjCBgDELMAkGA1UEBhMCUlUxDzANBgNVBAcMBk1vc2NvdzES",
+    "MBAGA1UECgwJU1RDLUF0bGFzMQ0wCwYDVQQLDARVWklTMRwwGgYDVQQDDBNEb2N1",
+    "bWVudF9TaWduZXJfMy41MR8wHQYJKoZIhvcNAQkBFhBjYW1haWxAc3RjbmV0LnJ1",
+    "MIIBSzCCAQMGByqGSM49AgEwgfcCAQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAA",
+    "AAAAAAAAAAAA////////////////MFsEIP////8AAAABAAAAAAAAAAAAAAAA////",
+    "///////////8BCBaxjXYqjqT57PrvVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMVBMSd",
+    "NgiG5wSTamZ44ROdJreBn36QBEEEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5",
+    "RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA",
+    "//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABNC/fO9tdWswlybyrKN5DWjq",
+    "RAU9SDs4v8QAnFHysSgJa/THOmGfV4Xc1IIlU0PPVaacEmqh2Uonpl6UEI4QRVaj",
+    "UjBQMA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQUh6hBQVQwYivY2H4KMSWkeXBD",
+    "XakwHwYDVR0jBBgwFoAUhQxT9xYOXe9kpWd898GEkgXSspwwCQYHKoZIzj0EAQNH",
+    "ADBEAiBtcZkULayUOn20W/FDY/XSa6gW4RCLLkbPDge7QZ3+mQIgMUxl931Jf6QP",
+    "O7f6y6mZ+dfR9n9rrjl57E2GC6Co3P8=",
+    "-----END CERTIFICATE-----",
+  ].join("\n");
+
+  // A valid PKCS#10 CSR (from the existing crypto tests)
+  const csrBase64 = "MIICdDCCAVwCAQAwLzEtMA8GA1UEAxMIdGVzdE5hbWUwGgYJKoZIhvcNAQkBEw10ZXN0QG1haWwubm90MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArut7tLrb1BEHXImMTWipet+3/J2isn7mBv278oP7YyOkmX/Vzxvk9nvSc/B1wh6kSo6nfaxYacNNSP3r+WQYaTeLm5TsDbUfCJYtvvTuYH0GVTM8Qm7QhMZKnyUy/D60WNcRM4pnBDSEMpKppi7HhfL37DZpQnsQfr9r8LQPWZ9t/mf+FsSeWyQOQcz+ob6cODfNQIvbzpaXXdNpKIHLPW+/e4af5/WlZ9wL5Sy7kOf4X6nErdl74s1vSji9goANSQkd5TbswtFPRNybikrrisz0HtsIq2uTGDY6t3iOEHTe5qe/ux4anjbSqKVuIQEQWQOKb4h+mHTc+EC5yknihQIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBAE7TU20ui1MLtxLM0UZMytYAjC7vtXxB5Vl6bzHUzZkVFW6oTeizqDxjeBtZ1SqErpgdyvzMvFSxF6f+679kl1/Zs2V0IPa4y58he3wTT/M1xCBN/bITY2cA4ETozbtK4cGoi6jY/0j8NcxTLfiBgwhE3ap+9GzLtWEhHWCXmpsohbvAktXSh1tLh4xmgoQoePEBSPbnaOmsonyzscKiBMASDvjrFdNbtD0uY2v/wYXwtRGvV/Q/O3lLWEosE4NdnZmgId4bm7ru48WucSnxuEJAkKUjDLrN0uqY/tKfX4Zy9w8Y/o+hk3QzNBVa3ZUvzDhVAmamQflvw3lXMm/JG4U=";
+
+  describe("X509Certificate", () => {
+    it("parses with default limits", () => {
+      const cert = new x509.X509Certificate(certPem);
+      expect(cert.serialNumber).toBeTruthy();
+    });
+
+    it("throws when berOptions.maxDepth is too low", () => {
+      expect(() => new x509.X509Certificate(certPem, { berOptions: { maxDepth: 1 } }))
+        .toThrow(/depth/i);
+    });
+
+    it("a tight-but-sufficient maxDepth still allows inspection (re-parse reuses options)", () => {
+      // Build the cert with explicit limits, then exercise the lazy re-parse paths
+      // (toString("asn") and toTextObject) which must reuse the stored options.
+      const cert = new x509.X509Certificate(certPem, { berOptions: { maxDepth: 100 } });
+      expect(typeof cert.toString("asn")).toBe("string");
+      expect(typeof cert.toString("text")).toBe("string");
+    });
+  });
+
+  describe("PublicKey", () => {
+    it("throws when berOptions.maxDepth is too low", () => {
+      const spki = new x509.X509Certificate(certPem).publicKey.rawData;
+      expect(() => new x509.PublicKey(spki, { berOptions: { maxDepth: 1 } }))
+        .toThrow(/depth/i);
+    });
+  });
+
+  describe("Pkcs10CertificateRequest", () => {
+    it("throws when berOptions.maxDepth is too low", () => {
+      const raw = Convert.FromBase64(csrBase64);
+      expect(() => new x509.Pkcs10CertificateRequest(raw, { berOptions: { maxDepth: 1 } }))
+        .toThrow(/depth/i);
+      // sanity: default parse works
+      expect(new x509.Pkcs10CertificateRequest(raw).subject).toBeDefined();
+    });
+  });
+
+  describe("X509Certificates (CMS)", () => {
+    it("forwards berOptions through import()", () => {
+      const cms = new x509.X509Certificates([new x509.X509Certificate(certPem)]).export("raw");
+      expect(() => new x509.X509Certificates(cms, { berOptions: { maxDepth: 1 } }))
+        .toThrow(/depth/i);
+      // sanity: default import works
+      expect(new x509.X509Certificates(cms).length).toBe(1);
+    });
+  });
+
+  describe("X509Crl", () => {
+    let crlRaw: ArrayBuffer;
+
+    beforeAll(async () => {
+      const alg = {
+        name: "ECDSA", hash: "SHA-256", namedCurve: "P-256",
+      };
+      const keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+      const crl = await x509.X509CrlGenerator.create({
+        issuer: "CN=Test CA",
+        thisUpdate: new Date("2023-01-01T00:00:00Z"),
+        nextUpdate: new Date("2023-01-08T00:00:00Z"),
+        signingAlgorithm: alg,
+        signingKey: keys.privateKey,
+        entries: [{
+          serialNumber: "010203", revocationDate: new Date("2023-01-02T00:00:00Z"),
+        }],
+      });
+      crlRaw = crl.rawData;
+    });
+
+    it("parses with default limits", () => {
+      const crl = new x509.X509Crl(crlRaw);
+      expect(crl.issuer).toBe("CN=Test CA");
+    });
+
+    it("throws when berOptions.maxDepth is too low", () => {
+      expect(() => new x509.X509Crl(crlRaw, { berOptions: { maxDepth: 1 } }))
+        .toThrow(/depth/i);
+    });
+
+    it("a tight-but-sufficient maxDepth still allows inspection (re-parse reuses options)", () => {
+      const crl = new x509.X509Crl(crlRaw, { berOptions: { maxDepth: 100 } });
+      expect(typeof crl.toString("asn")).toBe("string");
+      expect(typeof crl.toString("text")).toBe("string");
+    });
+  });
+});

--- a/test/parse_options.ts
+++ b/test/parse_options.ts
@@ -2,6 +2,10 @@ import {
   describe, it, expect, beforeAll,
 } from "vitest";
 import { Crypto } from "@peculiar/webcrypto";
+import { AsnConvert } from "@peculiar/asn1-schema";
+import { CertificationRequest } from "@peculiar/asn1-csr";
+import { id_pkcs9_at_extensionRequest } from "@peculiar/asn1-pkcs9";
+import * as asn1X509 from "@peculiar/asn1-x509";
 import { Convert } from "pvtsutils";
 import * as x509 from "../src";
 
@@ -121,6 +125,101 @@ describe("parse options (berOptions)", () => {
       const crl = new x509.X509Crl(crlRaw, { berOptions: { maxDepth: 100 } });
       expect(typeof crl.toString("asn")).toBe("string");
       expect(typeof crl.toString("text")).toBe("string");
+    });
+  });
+
+  // Extension and attribute values are parsed lazily, long after the top level
+  // structure. Those parsers must reuse the options the object was created
+  // with, otherwise raising the limits for a large input only helps the outer
+  // structure while the nested values still fail on the asn1js defaults.
+  describe("nested values", () => {
+    const alg = {
+      name: "ECDSA", hash: "SHA-256", namedCurve: "P-256",
+    };
+    // A certificate policies value of ~12000 ASN.1 nodes, above the 10000 default
+    const policies = new Array(6000).fill(0).map((_, i) => `1.2.3.4.${i}`);
+    const berOptions = { maxNodes: 100000 };
+    const notBefore = new Date("2023-01-01T00:00:00Z");
+    const notAfter = new Date("2023-01-08T00:00:00Z");
+
+    let keys: CryptoKeyPair;
+    let largeExtension: asn1X509.Extension;
+
+    beforeAll(async () => {
+      keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+      largeExtension = AsnConvert.parse(
+        new x509.CertificatePolicyExtension(policies).rawData,
+        asn1X509.Extension,
+      );
+    });
+
+    // NOTE: the generators parse their own output with the default limits, so
+    // the structures carrying the large value are assembled from ASN.1.
+
+    it("reuses the options for certificate extension values", async () => {
+      const cert = await x509.X509CertificateGenerator.createSelfSigned({
+        serialNumber: "01",
+        name: "CN=Test",
+        notBefore,
+        notAfter,
+        signingAlgorithm: alg,
+        keys,
+      });
+      const asn = AsnConvert.parse(cert.rawData, asn1X509.Certificate);
+      asn.tbsCertificate.extensions = new asn1X509.Extensions([largeExtension]);
+      const raw = AsnConvert.serialize(asn);
+
+      expect(() => new x509.X509Certificate(raw)).toThrow(/node count/i);
+
+      const parsed = new x509.X509Certificate(raw, { berOptions });
+      const ext = parsed.getExtension(x509.CertificatePolicyExtension);
+      expect(ext?.policies).toHaveLength(policies.length);
+    });
+
+    it("reuses the options for CRL entry extension values", async () => {
+      const crl = await x509.X509CrlGenerator.create({
+        issuer: "CN=Test CA",
+        thisUpdate: notBefore,
+        nextUpdate: notAfter,
+        signingAlgorithm: alg,
+        signingKey: keys.privateKey,
+        entries: [{
+          serialNumber: "010203", revocationDate: notBefore,
+        }],
+      });
+      const asn = AsnConvert.parse(crl.rawData, asn1X509.CertificateList);
+      asn.tbsCertList.revokedCertificates![0].crlEntryExtensions = [largeExtension];
+      const raw = AsnConvert.serialize(asn);
+
+      expect(() => new x509.X509Crl(raw)).toThrow(/node count/i);
+
+      const parsed = new x509.X509Crl(raw, { berOptions });
+      const fromEntries = parsed.entries[0].extensions[0] as x509.CertificatePolicyExtension;
+      expect(fromEntries.policies).toHaveLength(policies.length);
+      const fromFindRevoked = parsed.findRevoked("010203")!
+        .extensions[0] as x509.CertificatePolicyExtension;
+      expect(fromFindRevoked.policies).toHaveLength(policies.length);
+    });
+
+    it("reuses the options for CSR attribute values", async () => {
+      const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+        name: "CN=Test",
+        keys,
+        signingAlgorithm: alg,
+      });
+      const asn = AsnConvert.parse(csr.rawData, CertificationRequest);
+      asn.certificationRequestInfo.attributes.push(new asn1X509.Attribute({
+        type: id_pkcs9_at_extensionRequest,
+        values: [AsnConvert.serialize(new asn1X509.Extensions([largeExtension]))],
+      }));
+      const raw = AsnConvert.serialize(asn);
+
+      expect(() => new x509.Pkcs10CertificateRequest(raw)).toThrow(/node count/i);
+
+      const parsed = new x509.Pkcs10CertificateRequest(raw, { berOptions });
+      const ext = parsed
+        .getExtension(asn1X509.id_ce_certificatePolicies) as x509.CertificatePolicyExtension;
+      expect(ext.policies).toHaveLength(policies.length);
     });
   });
 });

--- a/test/parse_options.ts
+++ b/test/parse_options.ts
@@ -88,6 +88,19 @@ describe("parse options (berOptions)", () => {
       // sanity: default import works
       expect(new x509.X509Certificates(cms).length).toBe(1);
     });
+
+    it("keeps the collection and the options of the last successful import()", () => {
+      const cms = new x509.X509Certificates([new x509.X509Certificate(certPem)]).export("raw");
+      const certs = new x509.X509Certificates(cms);
+      const asn = certs.toString("asn");
+
+      expect(() => certs.import(cms, { berOptions: { maxDepth: 1 } })).toThrow(/depth/i);
+
+      expect(certs).toHaveLength(1);
+      expect(certs[0].serialNumber).toBe(new x509.X509Certificate(certPem).serialNumber);
+      // the failed import must not have replaced the stored parse options
+      expect(certs.toString("asn")).toBe(asn);
+    });
   });
 
   describe("X509Crl", () => {


### PR DESCRIPTION
This exposes the ASN.1 parse options for the reasons described in https://github.com/PeculiarVentures/asn1-schema/issues/134.

The options are exposed on the larger parsing entry points such as certificates, CRLs, CSRs, public keys, and certificate collections. They are also propagated through nested/lazy ASN.1 parsing (including extensions and attributes), so caller-provided resource limits remain consistent when inspecting nested values.