### PR TITLE
fix: don't apply fromBER limits when parsing our own DER

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { AsnData } from "./asn_data";
 import { OidSerializer, TextObject } from "./text_converter";
 import { ParseOptions } from "./types";
+import { selfProducedParseOptions } from "./utils";
 
 /**
  * Represents the Attribute structure
@@ -50,6 +51,7 @@ export class Attribute extends AsnData<AsnAttribute> {
           values,
         }),
       );
+      options = selfProducedParseOptions;
     }
 
     super(raw, AsnAttribute, options);

--- a/src/attributes/extensions.ts
+++ b/src/attributes/extensions.ts
@@ -7,6 +7,7 @@ import { Extension } from "../extension";
 import { ExtensionFactory } from "../extensions";
 import { TextObject } from "../text_converter";
 import { ParseOptions } from "../types";
+import { selfProducedParseOptions } from "../utils";
 
 export class ExtensionsAttribute extends Attribute {
   public static override NAME = "Extensions";
@@ -31,7 +32,9 @@ export class ExtensionsAttribute extends Attribute {
       const extensions = args[0] as Extension[];
       const value = new asnX509.Extensions();
       for (const extension of extensions) {
-        value.push(AsnConvert.parse(extension.rawData, asnX509.Extension));
+        value.push(
+          AsnConvert.parse(extension.rawData, asnX509.Extension, selfProducedParseOptions),
+        );
       }
       super(asnPkcs9.id_pkcs9_at_extensionRequest, [AsnConvert.serialize(value)]);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { BufferSourceConverter } from "pvtsutils";
 import { AsnData } from "./asn_data";
 import { OidSerializer, TextObject } from "./text_converter";
 import { ParseOptions } from "./types";
+import { selfProducedParseOptions } from "./utils";
 
 /**
  * Represents the certificate extension
@@ -50,6 +51,7 @@ export class Extension extends AsnData<AsnExtension> {
           extnValue: new OctetString(BufferSourceConverter.toArrayBuffer(args[2])),
         }),
       );
+      options = selfProducedParseOptions;
     }
 
     super(raw, AsnExtension, options);

--- a/src/extensions/authority_info_access.ts
+++ b/src/extensions/authority_info_access.ts
@@ -5,6 +5,7 @@ import { Extension } from "../extension";
 import { TextObject } from "../text_converter";
 import { GeneralName } from "../general_name";
 import { ParseOptions } from "../types";
+import { selfProducedParseOptions } from "../utils";
 
 export type AccessItemTypes = GeneralName | GeneralName[] | string | string[];
 export interface AuthorityInfoAccessParams {
@@ -160,7 +161,11 @@ function addAccessDescriptions(
       value.push(
         new asn1X509.AccessDescription({
           accessMethod: method,
-          accessLocation: AsnConvert.parse(url.rawData, asn1X509.GeneralName),
+          accessLocation: AsnConvert.parse(
+            url.rawData,
+            asn1X509.GeneralName,
+            selfProducedParseOptions,
+          ),
         }),
       );
     });

--- a/src/extensions/authority_key_identifier.ts
+++ b/src/extensions/authority_key_identifier.ts
@@ -7,6 +7,7 @@ import { cryptoProvider } from "../provider";
 import { PublicKey, PublicKeyType } from "../public_key";
 import { TextObject } from "../text_converter";
 import { ParseOptions } from "../types";
+import { selfProducedParseOptions } from "../utils";
 
 export interface CertificateIdentifier {
   /**
@@ -101,7 +102,8 @@ export class AuthorityKeyIdentifierExtension extends Extension {
       const certId = args[0] as CertificateIdentifier;
       const certIdName =
         certId.name instanceof GeneralNames
-          ? AsnConvert.parse(certId.name.rawData, asn1X509.GeneralNames)
+          ? // The GeneralNames instance already parsed this buffer.
+            AsnConvert.parse(certId.name.rawData, asn1X509.GeneralNames, selfProducedParseOptions)
           : certId.name;
       const value = new asn1X509.AuthorityKeyIdentifier({
         authorityCertIssuer: certIdName,

--- a/src/general_name.ts
+++ b/src/general_name.ts
@@ -4,6 +4,8 @@ import { BufferSourceConverter, Convert } from "pvtsutils";
 import { AsnData } from "./asn_data";
 import { Name } from "./name";
 import { OidSerializer, TextObject } from "./text_converter";
+import { ParseOptions } from "./types";
+import { selfProducedParseOptions } from "./utils";
 
 const ERR_GN_CONSTRUCTOR = "Cannot initialize GeneralName from ASN.1 data.";
 const ERR_GN_STRING_FORMAT = `${ERR_GN_CONSTRUCTOR} Unsupported string format in use.`;
@@ -55,16 +57,24 @@ export class GeneralName extends AsnData<asn1X509.GeneralName> {
   public value!: string;
 
   public constructor(type: GeneralNameType, value: string);
-  public constructor(asn: asn1X509.GeneralName);
-  public constructor(raw: BufferSource);
+  public constructor(asn: asn1X509.GeneralName, options?: ParseOptions);
+  public constructor(raw: BufferSource, options?: ParseOptions);
   public constructor(...args: any[]) {
     let name: asn1X509.GeneralName;
-    if (args.length === 2) {
+    let options: ParseOptions | undefined;
+    // NOTE: the BufferSource check comes first because `new GeneralName(raw, options)`
+    // also has two arguments and must not fall into the `(type, value)` branch
+    if (BufferSourceConverter.isBufferSource(args[0])) {
+      // raw: BufferSource, options?: ParseOptions
+      options = args[1];
+      name = AsnConvert.parse(args[0], asn1X509.GeneralName, options);
+    } else if (typeof args[0] === "string") {
       // type: GeneralNameType, value: string
+      options = selfProducedParseOptions;
       switch (args[0] as GeneralNameType) {
         case DN: {
           const derName = new Name(args[1]).toArrayBuffer();
-          const asnName = AsnConvert.parse(derName, asn1X509.Name);
+          const asnName = AsnConvert.parse(derName, asn1X509.Name, selfProducedParseOptions);
           name = new asn1X509.GeneralName({ directoryName: asnName });
           break;
         }
@@ -119,14 +129,12 @@ export class GeneralName extends AsnData<asn1X509.GeneralName> {
         default:
           throw new Error("Cannot create GeneralName. Unsupported type of the name");
       }
-    } else if (BufferSourceConverter.isBufferSource(args[0])) {
-      // raw: BufferSource
-      name = AsnConvert.parse(args[0], asn1X509.GeneralName);
     } else {
-      // asn: asn1X509.GeneralName
+      // asn: asn1X509.GeneralName, options?: ParseOptions
       name = args[0];
+      options = args[1] ?? selfProducedParseOptions;
     }
-    super(name);
+    super(name, options);
   }
 
   /**
@@ -158,7 +166,7 @@ export class GeneralName extends AsnData<asn1X509.GeneralName> {
     } else if (asn.otherName != undefined) {
       if (asn.otherName.typeId === id_GUID) {
         this.type = GUID;
-        const guid = AsnConvert.parse(asn.otherName.value, OctetString);
+        const guid = AsnConvert.parse(asn.otherName.value, OctetString, this.parseOptions);
         const matches = new RegExp(GUID_REGEX, "i").exec(Convert.ToHex(guid));
         if (!matches) {
           throw new Error(ERR_GUID);
@@ -175,7 +183,11 @@ export class GeneralName extends AsnData<asn1X509.GeneralName> {
           .join("-");
       } else if (asn.otherName.typeId === id_UPN) {
         this.type = UPN;
-        this.value = AsnConvert.parse(asn.otherName.value, asn1X509.DirectoryString).toString();
+        this.value = AsnConvert.parse(
+          asn.otherName.value,
+          asn1X509.DirectoryString,
+          this.parseOptions,
+        ).toString();
       } else {
         throw new Error(ERR_GN_STRING_FORMAT);
       }
@@ -228,11 +240,19 @@ export class GeneralNames extends AsnData<asn1X509.GeneralNames> {
 
   constructor(json: JsonGeneralNames);
   constructor(asn: asn1X509.GeneralNames | asn1X509.GeneralName[]);
-  constructor(raw: BufferSource);
+  /**
+   * Creates a new instance from DER encoded buffer
+   * @param raw DER encoded buffer
+   * @param options Optional ASN.1 parse options (e.g. `asn1js.fromBER` resource limits)
+   */
+  constructor(raw: BufferSource, options?: ParseOptions);
   constructor(
     params: JsonGeneralNames | asn1X509.GeneralNames | asn1X509.GeneralName[] | BufferSource,
+    options?: ParseOptions,
   ) {
     let names: asn1X509.GeneralNames;
+    // Only the raw overload takes DER from the caller; the others are built here
+    let stored = selfProducedParseOptions;
     if (params instanceof asn1X509.GeneralNames) {
       // asn1X509.GeneralNames
       names = params;
@@ -247,6 +267,7 @@ export class GeneralNames extends AsnData<asn1X509.GeneralNames> {
           const asnName = AsnConvert.parse(
             new GeneralName(name.type, name.value).rawData,
             asn1X509.GeneralName,
+            selfProducedParseOptions,
           );
           items.push(asnName);
         }
@@ -254,12 +275,13 @@ export class GeneralNames extends AsnData<asn1X509.GeneralNames> {
 
       names = new asn1X509.GeneralNames(items);
     } else if (BufferSourceConverter.isBufferSource(params)) {
-      names = AsnConvert.parse(params, asn1X509.GeneralNames);
+      names = AsnConvert.parse(params, asn1X509.GeneralNames, options);
+      stored = options ?? {};
     } else {
       throw new Error("Cannot initialize GeneralNames. Incorrect incoming arguments");
     }
 
-    super(names);
+    super(names, stored);
   }
 
   protected onInit(asn: asn1X509.GeneralNames): void {
@@ -267,7 +289,7 @@ export class GeneralNames extends AsnData<asn1X509.GeneralNames> {
     for (const asnName of asn) {
       let name: GeneralName | null = null;
       try {
-        name = new GeneralName(asnName);
+        name = new GeneralName(asnName, this.parseOptions);
       } catch {
         // skip unsupported ASN.1 GeneralName
         continue;

--- a/src/pkcs10_cert_req_generator.ts
+++ b/src/pkcs10_cert_req_generator.ts
@@ -17,6 +17,7 @@ import { JsonName, Name } from "./name";
 import { Pkcs10CertificateRequest } from "./pkcs10_cert_req";
 import { HashedAlgorithm } from "./types";
 import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature_formatter";
+import { selfProducedParseOptions } from "./utils";
 
 export type Pkcs10CertificateRequestCreateParamsName = string | JsonName | Name;
 
@@ -69,18 +70,24 @@ export class Pkcs10CertificateRequestGenerator {
     const spki = await crypto.subtle.exportKey("spki", params.keys.publicKey);
     const asnReq = new CertificationRequest({
       certificationRequestInfo: new CertificationRequestInfo({
-        subjectPKInfo: AsnConvert.parse(spki, SubjectPublicKeyInfo),
+        subjectPKInfo: AsnConvert.parse(spki, SubjectPublicKeyInfo, selfProducedParseOptions),
       }),
     });
     if (params.name) {
       const name = params.name instanceof Name ? params.name : new Name(params.name);
-      asnReq.certificationRequestInfo.subject = AsnConvert.parse(name.toArrayBuffer(), AsnName);
+      asnReq.certificationRequestInfo.subject = AsnConvert.parse(
+        name.toArrayBuffer(),
+        AsnName,
+        selfProducedParseOptions,
+      );
     }
 
     if (params.attributes) {
       // Add attributes
       for (const o of params.attributes) {
-        asnReq.certificationRequestInfo.attributes.push(AsnConvert.parse(o.rawData, AsnAttribute));
+        asnReq.certificationRequestInfo.attributes.push(
+          AsnConvert.parse(o.rawData, AsnAttribute, selfProducedParseOptions),
+        );
       }
     }
 
@@ -89,7 +96,7 @@ export class Pkcs10CertificateRequestGenerator {
       const attr = new AsnAttribute({ type: id_pkcs9_at_extensionRequest });
       const extensions = new Extensions();
       for (const o of params.extensions) {
-        extensions.push(AsnConvert.parse(o.rawData, AsnExtension));
+        extensions.push(AsnConvert.parse(o.rawData, AsnExtension, selfProducedParseOptions));
       }
       attr.values.push(AsnConvert.serialize(extensions));
       asnReq.certificationRequestInfo.attributes.push(attr);
@@ -124,6 +131,6 @@ export class Pkcs10CertificateRequestGenerator {
 
     asnReq.signature = asnSignature;
 
-    return new Pkcs10CertificateRequest(AsnConvert.serialize(asnReq));
+    return new Pkcs10CertificateRequest(AsnConvert.serialize(asnReq), selfProducedParseOptions);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,29 @@
 import { BufferSourceConverter, Convert } from "pvtsutils";
 import { cryptoProvider } from "./provider";
+import { ParseOptions } from "./types";
+
+/**
+ * Parse options for DER this library produced itself.
+ *
+ * Objects here keep their value as DER and re-parse it to derive the ASN.1 view, so
+ * creating one involves several serialize/parse round-trips of bytes built from
+ * structures already in memory. The `asn1js` limits exist to bound untrusted input;
+ * applying them to those round-trips protects nothing and caps what a caller may build
+ * (10000 nodes is roughly 2500 RDNs). So limits apply to DER the caller handed us -- the
+ * `raw` / `AsnEncodedType` constructors, and a raw `publicKey` -- and not to ours.
+ *
+ * Note that an object built this way stores these options, so its lazy accessors are
+ * unlimited too, including for foreign DER embedded in it. Bound such input on the way in
+ * with {@link ExtensionFactory.create} or a concrete extension class, which parse the
+ * value; `new Extension(raw)` only parses the wrapper.
+ */
+export const selfProducedParseOptions: ParseOptions = {
+  berOptions: {
+    maxDepth: Infinity,
+    maxNodes: Infinity,
+    maxContentLength: Infinity,
+  },
+};
 
 /**
  * Encodes serial number bytes as the content octets of a positive ASN.1 INTEGER by:

--- a/src/x509_cert_generator.ts
+++ b/src/x509_cert_generator.ts
@@ -6,11 +6,11 @@ import { cryptoProvider } from "./provider";
 import { AlgorithmProvider, diAlgorithmProvider } from "./algorithm";
 import { Extension } from "./extension";
 import { JsonName, Name } from "./name";
-import { HashedAlgorithm } from "./types";
+import { HashedAlgorithm, ParseOptions } from "./types";
 import { X509Certificate } from "./x509_cert";
 import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature_formatter";
 import { PublicKey, PublicKeyType } from "./public_key";
-import { generateCertificateSerialNumber } from "./utils";
+import { generateCertificateSerialNumber, selfProducedParseOptions } from "./utils";
 
 export type X509CertificateCreateParamsName = string | JsonName | Name;
 
@@ -126,12 +126,18 @@ export class X509CertificateGenerator {
    */
   public static async create(params: X509CertificateCreateParams, crypto = cryptoProvider.get()) {
     let spki: BufferSource;
+    // A raw SPKI is the only DER here the caller did not get from this library, so it
+    // keeps the asn1js defaults. They are never in the way (a real SubjectPublicKeyInfo
+    // is 7-16 nodes against a 10000 default); to move them, parse it with
+    // `new PublicKey(raw, options)` and pass that instead.
+    let spkiOptions: ParseOptions | undefined = selfProducedParseOptions;
     if (params.publicKey instanceof PublicKey) {
       spki = params.publicKey.rawData;
     } else if ("publicKey" in params.publicKey) {
       spki = params.publicKey.publicKey.rawData;
     } else if (BufferSourceConverter.isBufferSource(params.publicKey)) {
       spki = params.publicKey;
+      spkiOptions = undefined;
     } else {
       spki = await crypto.subtle.exportKey("spki", params.publicKey);
     }
@@ -149,18 +155,28 @@ export class X509CertificateGenerator {
           notAfter,
         }),
         extensions: new asn1X509.Extensions(
-          params.extensions?.map((o) => AsnConvert.parse(o.rawData, asn1X509.Extension)) || [],
+          params.extensions?.map((o) =>
+            AsnConvert.parse(o.rawData, asn1X509.Extension, selfProducedParseOptions),
+          ) || [],
         ),
-        subjectPublicKeyInfo: AsnConvert.parse(spki, asn1X509.SubjectPublicKeyInfo),
+        subjectPublicKeyInfo: AsnConvert.parse(spki, asn1X509.SubjectPublicKeyInfo, spkiOptions),
       }),
     });
     if (params.subject) {
       const name = params.subject instanceof Name ? params.subject : new Name(params.subject);
-      asnX509.tbsCertificate.subject = AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name);
+      asnX509.tbsCertificate.subject = AsnConvert.parse(
+        name.toArrayBuffer(),
+        asn1X509.Name,
+        selfProducedParseOptions,
+      );
     }
     if (params.issuer) {
       const name = params.issuer instanceof Name ? params.issuer : new Name(params.issuer);
-      asnX509.tbsCertificate.issuer = AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name);
+      asnX509.tbsCertificate.issuer = AsnConvert.parse(
+        name.toArrayBuffer(),
+        asn1X509.Name,
+        selfProducedParseOptions,
+      );
     }
 
     // Set signing algorithm
@@ -210,6 +226,6 @@ export class X509CertificateGenerator {
 
     asnX509.signatureValue = asnSignature;
 
-    return new X509Certificate(AsnConvert.serialize(asnX509));
+    return new X509Certificate(AsnConvert.serialize(asnX509), selfProducedParseOptions);
   }
 }

--- a/src/x509_crl_generator.ts
+++ b/src/x509_crl_generator.ts
@@ -12,7 +12,7 @@ import { diAsnSignatureFormatter, IAsnSignatureFormatter } from "./asn_signature
 import { X509CrlEntry, X509CrlReason } from "./x509_crl_entry";
 import { X509Crl } from "./x509_crl";
 import { X509CertificateCreateParamsName } from "./x509_cert_generator";
-import { normalizeCertificateSerialNumber } from "./utils";
+import { normalizeCertificateSerialNumber, selfProducedParseOptions } from "./utils";
 
 export interface X509CrlEntryParams {
   /**
@@ -62,7 +62,7 @@ export class X509CrlGenerator {
     const asnX509Crl = new asn1X509.CertificateList({
       tbsCertList: new asn1X509.TBSCertList({
         version: asn1X509.Version.v2,
-        issuer: AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name),
+        issuer: AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name, selfProducedParseOptions),
         thisUpdate: new Time(params.thisUpdate || new Date()),
       }),
     });
@@ -73,7 +73,9 @@ export class X509CrlGenerator {
 
     if (params.extensions && params.extensions.length) {
       asnX509Crl.tbsCertList.crlExtensions = new asn1X509.Extensions(
-        params.extensions.map((o) => AsnConvert.parse(o.rawData, asn1X509.Extension)) || [],
+        params.extensions.map((o) =>
+          AsnConvert.parse(o.rawData, asn1X509.Extension, selfProducedParseOptions),
+        ) || [],
       );
     }
 
@@ -97,7 +99,7 @@ export class X509CrlGenerator {
 
         if ("extensions" in entry && entry.extensions?.length) {
           revokedCert.crlEntryExtensions = entry.extensions.map((o) =>
-            AsnConvert.parse(o.rawData, asn1X509.Extension),
+            AsnConvert.parse(o.rawData, asn1X509.Extension, selfProducedParseOptions),
           );
         } else {
           revokedCert.crlEntryExtensions = [];
@@ -138,7 +140,9 @@ export class X509CrlGenerator {
                 extnID: asn1X509.id_ce_certificateIssuer,
                 critical: false,
                 extnValue: new OctetString(
-                  AsnConvert.serialize(AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name)),
+                  AsnConvert.serialize(
+                    AsnConvert.parse(name.toArrayBuffer(), asn1X509.Name, selfProducedParseOptions),
+                  ),
                 ),
               }),
             );
@@ -179,6 +183,6 @@ export class X509CrlGenerator {
 
     asnX509Crl.signature = asnSignature;
 
-    return new X509Crl(AsnConvert.serialize(asnX509Crl));
+    return new X509Crl(AsnConvert.serialize(asnX509Crl), selfProducedParseOptions);
   }
 }

--- a/test/parse_options.ts
+++ b/test/parse_options.ts
@@ -4,6 +4,7 @@ import { AsnConvert } from "@peculiar/asn1-schema";
 import { CertificationRequest } from "@peculiar/asn1-csr";
 import { id_pkcs9_at_extensionRequest } from "@peculiar/asn1-pkcs9";
 import * as asn1X509 from "@peculiar/asn1-x509";
+import * as asn1js from "asn1js";
 import { Convert } from "pvtsutils";
 import * as x509 from "../src";
 
@@ -173,8 +174,9 @@ describe("parse options (berOptions)", () => {
       );
     });
 
-    // NOTE: the generators parse their own output with the default limits, so
-    // the structures carrying the large value are assembled from ASN.1.
+    // NOTE: these assemble the structures from ASN.1 rather than through the
+    // generators, so they exercise the parsing classes on their own. What the
+    // generators themselves do with the options is covered separately below.
 
     it("reuses the options for certificate extension values", async () => {
       const cert = await x509.X509CertificateGenerator.createSelfSigned({
@@ -246,6 +248,281 @@ describe("parse options (berOptions)", () => {
         asn1X509.id_ce_certificatePolicies,
       ) as x509.CertificatePolicyExtension;
       expect(ext.policies).toHaveLength(policies.length);
+    });
+  });
+
+  // Creating is not parsing untrusted input.
+  //
+  // Almost every class here keeps its value as DER and re-derives the ASN.1 view by
+  // parsing it again, so building an object involves several serialize/parse round-trips
+  // of bytes this library produced moments earlier from structures the caller already
+  // holds. Creating and reading back one certificate costs ~13 parses, none of which
+  // crosses a trust boundary. Applying the asn1js limits to those capped what a caller
+  // was allowed to build at 10000 nodes -- roughly 2500 RDNs -- and reported it as
+  // "Maximum ASN.1 node count exceeded", which reads like a security rejection but was
+  // the library refusing to build the caller's own data.
+  //
+  // The rule is now: limits apply to DER the caller handed us, not to DER we produced.
+  // These two blocks pin both halves of it. Every test in the first block threw before
+  // the rule was applied.
+  describe("creation is not limited", () => {
+    const alg = { name: "ECDSA", hash: "SHA-256", namedCurve: "P-256" };
+    // 3000 RDNs is 12001 ASN.1 nodes; the default ceiling is 10000
+    const largeName: x509.JsonName = Array.from({ length: 3000 }, (_, i) => ({ CN: [`n${i}`] }));
+    const policies = Array.from({ length: 6000 }, (_, i) => `1.2.3.4.${i}`);
+    const notBefore = new Date("2023-01-01T00:00:00Z");
+    const notAfter = new Date("2023-01-08T00:00:00Z");
+
+    let keys: CryptoKeyPair;
+
+    beforeAll(async () => {
+      keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+    });
+
+    it("X509CertificateGenerator builds a subject and issuer past the default limit", async () => {
+      const cert = await x509.X509CertificateGenerator.create({
+        serialNumber: "01",
+        subject: largeName,
+        issuer: largeName,
+        notBefore,
+        notAfter,
+        signingAlgorithm: alg,
+        signingKey: keys.privateKey,
+        publicKey: keys.publicKey,
+      });
+
+      expect(cert.subjectName.toJSON()).toHaveLength(largeName.length);
+      expect(cert.issuerName.toJSON()).toHaveLength(largeName.length);
+    });
+
+    it("X509CertificateGenerator builds and reads back a large extension", async () => {
+      const cert = await x509.X509CertificateGenerator.createSelfSigned({
+        serialNumber: "01",
+        name: "CN=Test",
+        notBefore,
+        notAfter,
+        signingAlgorithm: alg,
+        keys,
+        extensions: [new x509.CertificatePolicyExtension(policies)],
+      });
+
+      // reading it back is the other half: the lazy accessors re-parse too
+      const ext = cert.getExtension(x509.CertificatePolicyExtension);
+      expect(ext?.policies).toHaveLength(policies.length);
+    });
+
+    it("X509CrlGenerator builds an issuer past the default limit", async () => {
+      const crl = await x509.X509CrlGenerator.create({
+        issuer: largeName,
+        thisUpdate: notBefore,
+        nextUpdate: notAfter,
+        signingAlgorithm: alg,
+        signingKey: keys.privateKey,
+        extensions: [new x509.CertificatePolicyExtension(policies)],
+      });
+
+      expect(crl.issuerName.toJSON()).toHaveLength(largeName.length);
+      expect((crl.extensions[0] as x509.CertificatePolicyExtension).policies).toHaveLength(
+        policies.length,
+      );
+    });
+
+    it("Pkcs10CertificateRequestGenerator builds a subject past the default limit", async () => {
+      const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+        name: largeName,
+        keys,
+        signingAlgorithm: alg,
+      });
+
+      expect(csr.subjectName.toJSON()).toHaveLength(largeName.length);
+    });
+
+    it("GeneralName builds a dn past the default limit", () => {
+      const dn = largeName.map((rdn) => `CN=${rdn.CN[0]}`).join(", ");
+
+      expect(new x509.GeneralName("dn", dn).type).toBe("dn");
+    });
+
+    it("AuthorityKeyIdentifierExtension builds from a large GeneralNames", () => {
+      const nameBer = asn1js.fromBER(new x509.Name(largeName).toArrayBuffer(), {
+        maxNodes: 100000,
+      }).result;
+      const generalNamesRaw = new asn1js.Sequence({
+        value: [
+          new asn1js.Constructed({ idBlock: { tagClass: 3, tagNumber: 4 }, value: [nameBer] }),
+        ],
+      }).toBER();
+      // the GeneralNames itself is parsed from DER, so it still takes options
+      const names = new x509.GeneralNames(generalNamesRaw, { berOptions: { maxNodes: 100000 } });
+
+      const ext = new x509.AuthorityKeyIdentifierExtension({ name: names, serialNumber: "010203" });
+      expect(ext.certId?.serialNumber).toBe("010203");
+    });
+
+    // KNOWN UPSTREAM DEFECT, reachable through the ordinary CSR API and not fixable
+    // here. `Attribute` values are `AsnPropTypes.Any`, and `AsnAnyConverter.toASN`
+    // re-parses each value with `fromBER` and no options on the *serialize* path
+    // (@peculiar/asn1-schema 2.9.4, converters.js). The PKCS#10 generator puts the
+    // whole serialized `Extensions` blob into one such value, so building a CSR walks
+    // straight through it.
+    //
+    // What is rejected is not genuinely oversized: the blob has ~7 real nodes. asn1js
+    // speculatively parses the payload of a primitive OCTET STRING on the shared node
+    // counter and swallows the error without restoring the count, so a large extension
+    // burns the budget and the *next* extension trips the check. That makes the failure
+    // depend on extension order -- see the `it.fails` case below -- and it is why
+    // `ExtensionsAttribute([bigExt])` alone works while `[bigExt, otherExt]` does not.
+    //
+    // Certificates and CRLs are unaffected: their extensions are a typed SEQUENCE
+    // rather than an ANY, so nothing re-parses them on the way out.
+    it("ExtensionsAttribute builds and reads back its extensions", () => {
+      const attr = new x509.ExtensionsAttribute([new x509.CertificatePolicyExtension(policies)]);
+
+      expect(attr.items).toHaveLength(1);
+      expect((attr.items[0] as x509.CertificatePolicyExtension).policies).toHaveLength(
+        policies.length,
+      );
+      expect(attr.type).toBe(id_pkcs9_at_extensionRequest);
+    });
+  });
+
+  // Documents the upstream defect described above, through the public API that
+  // reaches it. The body asserts the behaviour we *want*; `it.fails` records that it
+  // does not hold yet, so this turns into a failure the day asn1js stops poisoning its
+  // node counter (or asn1-schema forwards options on serialize) and can then be
+  // promoted to a normal test. asn1js 3.0.10 / @peculiar/asn1-schema 2.9.4 are the
+  // latest published versions as of writing, so there is nothing to upgrade to.
+  it.fails("CSR extensions should build regardless of their order", async () => {
+    const alg = { name: "ECDSA", hash: "SHA-256", namedCurve: "P-256" };
+    const keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+    const large = new x509.CertificatePolicyExtension(
+      Array.from({ length: 6000 }, (_, i) => `1.2.3.4.${i}`),
+    );
+    const smaller = new x509.BasicConstraintsExtension(true, 2);
+
+    // this order works today, because the limit error is raised inside the trailing
+    // OCTET STRING and discarded
+    await x509.Pkcs10CertificateRequestGenerator.create({
+      name: "CN=Test",
+      keys,
+      signingAlgorithm: alg,
+      extensions: [smaller, large],
+    });
+
+    // the same extensions the other way round currently throw "node count exceeded"
+    await x509.Pkcs10CertificateRequestGenerator.create({
+      name: "CN=Test",
+      keys,
+      signingAlgorithm: alg,
+      extensions: [large, smaller],
+    });
+  });
+
+  describe("parsing is still limited", () => {
+    const alg = { name: "ECDSA", hash: "SHA-256", namedCurve: "P-256" };
+    const largeName: x509.JsonName = Array.from({ length: 3000 }, (_, i) => ({ CN: [`n${i}`] }));
+    const options = { berOptions: { maxNodes: 100000 } };
+
+    let keys: CryptoKeyPair;
+
+    beforeAll(async () => {
+      keys = await crypto.subtle.generateKey(alg, true, ["sign", "verify"]);
+    });
+
+    it("DER a generator produced still needs raised options to parse back", async () => {
+      // The generator can build it; taking those same bytes back in through a parse
+      // constructor is a different question, and there the defaults still apply.
+      const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+        name: largeName,
+        keys,
+        signingAlgorithm: alg,
+      });
+
+      expect(() => new x509.Pkcs10CertificateRequest(csr.rawData)).toThrow(/node count/i);
+
+      const parsed = new x509.Pkcs10CertificateRequest(csr.rawData, options);
+      expect(parsed.subjectName.toJSON()).toHaveLength(largeName.length);
+    });
+
+    it("a raw publicKey is bounded by the defaults, and PublicKey is the way round it", async () => {
+      // A raw SPKI is the one piece of DER a generator parses that the caller did not
+      // get from this library, so the asn1js defaults still apply to it. There is no
+      // option on the generator to change that, and none is needed: a real
+      // SubjectPublicKeyInfo is 7-16 nodes against a 10000 node default. A caller who
+      // does need to move the limits parses it themselves and passes the result.
+      //
+      // The payload below is nested 99 deep in `AlgorithmIdentifier.parameters`, which
+      // is an ANY and so is parsed for real. Depth is used rather than node count
+      // because `AsnAnyConverter.toASN` re-parses that value with no options on the way
+      // back out, so a node-heavy payload would break serialization instead. Nested 99
+      // the parameters still parse standalone under the default limit of 100, but the
+      // two extra levels of SPKI wrapping put them over it.
+      let parameters: asn1js.AsnType = new asn1js.Null();
+      for (let i = 0; i < 99; i++) {
+        parameters = new asn1js.Sequence({ value: [parameters] });
+      }
+      const spki = new asn1js.Sequence({
+        value: [
+          new asn1js.Sequence({
+            value: [new asn1js.ObjectIdentifier({ value: "1.2.3.4" }), parameters],
+          }),
+          new asn1js.BitString({ valueHex: new Uint8Array(32).buffer }),
+        ],
+      }).toBER();
+
+      const params = {
+        serialNumber: "01",
+        subject: "CN=Test",
+        issuer: "CN=Test",
+        signingAlgorithm: alg,
+        signingKey: keys.privateKey,
+      };
+
+      await expect(
+        x509.X509CertificateGenerator.create({ ...params, publicKey: spki }),
+      ).rejects.toThrow(/depth/i);
+
+      // the escape hatch: parse it explicitly, under limits the caller chooses, and
+      // hand the generator something already validated
+      const publicKey = new x509.PublicKey(spki, { berOptions: { maxDepth: 1000 } });
+      const cert = await x509.X509CertificateGenerator.create({ ...params, publicKey });
+
+      const asn = AsnConvert.parse(cert.rawData, asn1X509.Certificate, {
+        berOptions: { maxDepth: 1000 },
+      });
+      expect(AsnConvert.serialize(asn.tbsCertificate.subjectPublicKeyInfo).byteLength).toBe(
+        spki.byteLength,
+      );
+    });
+
+    it("GeneralName honours the options", () => {
+      const nameBer = asn1js.fromBER(new x509.Name(largeName).toArrayBuffer(), {
+        maxNodes: 100000,
+      }).result;
+      const raw = new asn1js.Constructed({
+        idBlock: { tagClass: 3, tagNumber: 4 },
+        value: [nameBer],
+      }).toBER();
+
+      expect(() => new x509.GeneralName(raw)).toThrow(/node count/i);
+      expect(new x509.GeneralName(raw, options).type).toBe("dn");
+    });
+
+    it("GeneralNames honours the options", () => {
+      const nameBer = asn1js.fromBER(new x509.Name(largeName).toArrayBuffer(), {
+        maxNodes: 100000,
+      }).result;
+      const raw = new asn1js.Sequence({
+        value: [
+          new asn1js.Constructed({ idBlock: { tagClass: 3, tagNumber: 4 }, value: [nameBer] }),
+        ],
+      }).toBER();
+
+      expect(() => new x509.GeneralNames(raw)).toThrow(/node count/i);
+
+      const names = new x509.GeneralNames(raw, options);
+      expect(names.items).toHaveLength(1);
+      expect(names.items[0].type).toBe("dn");
     });
   });
 });


### PR DESCRIPTION
Sister PR to https://github.com/PeculiarVentures/asn1-schema/pull/156.

Objects here keep their value as DER and re-parse it to derive the ASN.1 view, so creating one costs several serialize/parse round-trips of bytes built from structures already in memory. Applying the asn1js limits to those protected nothing and capped what a caller could build at 10000 nodes errored.

Limits now apply only to DER the caller handed us: the raw / AsnEncodedType constructors, and a raw publicKey. Round-trips use selfProducedParseOptions.

Also adds ParseOptions to the GeneralName and GeneralNames raw constructors, which had no way to pass them at all.